### PR TITLE
Fix dynamic title lookup and export, adjust rich text parsing

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -231,7 +231,8 @@ function parseRichText(text) {
     let lastIndex = 0;
     let match;
 
-    text = text.replace(/\**/g, "");
+    // Remove asteriscos simples utilizados para marcação (*, **)
+    text = text.replace(/\*/g, "");
     // Itera sobre as URLs encontradas
     while ((match = urlRegex.exec(text)) !== null) {
         // Adiciona o texto antes da URL, se houver

--- a/src/index.js
+++ b/src/index.js
@@ -61,11 +61,19 @@ function extractTagsSmart(blocks) {
 
 
 // Utilidade: Buscar página pelo título dentro do database
+// Corrigido para detectar dinamicamente o nome do campo do tipo "title"
 async function searchPageByTitle(notion, databaseId, title) {
+    // Busca o schema do database para descobrir o campo de título correto
+    const db = await notion.databases.retrieve({ database_id: databaseId });
+    const titlePropName = Object.entries(db.properties).find(
+        ([, val]) => val.type === "title"
+    )?.[0];
+    if (!titlePropName) return null;
+
     const response = await notion.databases.query({
         database_id: databaseId,
         filter: {
-            property: "title",
+            property: titlePropName,
             title: { equals: title }
         }
     });
@@ -149,10 +157,6 @@ function getRandomNotionColor() {
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
-
-module.exports = { getOrCreateTags };
-
-
 
 // Helper para garantir que só manda propriedades válidas
 function filterValidProperties(inputProps, dbProperties) {
@@ -585,4 +589,5 @@ if (require.main === module) {
     app.listen(port, () => console.log(`API up at http://localhost:${port}`));
 }
 
-module.exports = app;
+// Exporta o app juntamente com utilidades
+module.exports = { app, getOrCreateTags };


### PR DESCRIPTION
## Summary
- dynamically resolve title field in `searchPageByTitle`
- avoid removing entire strings when stripping `*` characters
- export app alongside utilities to avoid overwritten exports

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ba3d938832c83edf4c5153879aa