### PR TITLE
Fix notion content endpoint

### DIFF
--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -46,6 +46,23 @@
           "200": { "description": "Sucesso" }
         }
       }
+    },
+    "/notion-content": {
+      "get": {
+        "operationId": "buscarConteudoNotion",
+        "description": "Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.",
+        "parameters": [
+          { "name": "notion_token", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "nome_database", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "tema", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "subtitulo", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "tipo", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 } }
+        ],
+        "responses": {
+          "200": { "description": "Sucesso" }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
## Summary
- fix filter logic in `/notion-content` route
- expose `GET /notion-content` in OpenAPI spec

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684146217d60832c9dd745550b53a638