### PR TITLE
Update prompt with all API endpoints

### DIFF
--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -74,9 +74,22 @@
           { "name": "tipo", "in": "query", "required": false, "schema": { "type": "string" } },
           { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 } }
         ],
-        "responses": {
-          "200": { "description": "Sucesso" }
-        }
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
+    "/atualizar-titulos-e-tags": {
+      "post": {
+        "operationId": "atualizarTitulosETags",
+        "description": "Atualiza títulos e tags das subpáginas de um tema no Notion.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AtualizarTitulosETags" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
       }
     }
   },
@@ -171,6 +184,24 @@
           "tags": { "type": "string" }
         },
         "required": ["tema", "cronograma", "notion_token"]
+      },
+      "AtualizarTitulosETags": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          },
+          "tema": {
+            "type": "string",
+            "description": "Tema cujas subpáginas devem ser atualizadas"
+          }
+        },
+        "required": ["notion_token", "tema"]
       }
     }
   }

--- a/gpt/prompt.md
+++ b/gpt/prompt.md
@@ -157,6 +157,32 @@ Recapitule os aprendizados e indique próximos passos ou leituras.
 }
 ```
 
+### 📥 JSON para Cronograma
+
+```json
+{
+  "notion_token": "ntn_xxx",
+  "nome_database": "[Tema Pai do Pai]",
+  "tema": "[Tema PAI]",
+  "cronograma": [
+    {
+      "atividade": "Descrição da tarefa",
+      "descricao": "Detalhes ou objetivo",
+      "data": "2025-05-27T22:00:00Z"
+    }
+  ],
+  "tags": "cronograma, estudos"
+}
+```
+
+### 📤 Buscar conteúdo existente
+
+Use o endpoint `/notion-content` para listar resumos, flashcards ou cronogramas já salvos no Notion. Envie filtros como `tema`, `subtitulo` ou `tipo` e mostre os resultados ao usuário.
+
+### 🛠 Atualizar títulos e tags
+
+O endpoint `/atualizar-titulos-e-tags` revisa as subpáginas de um tema e ajusta automaticamente o título e as tags registradas no Notion.
+
 ## 🛠 Configuração do Notion
 
 1. Criar um Token de Integração em: https://www.notion.so/my-integrations


### PR DESCRIPTION
## Summary
- document new endpoint `/atualizar-titulos-e-tags` in OpenAPI spec
- update OpenAPI schemas for the new action
- expand prompt with cronograma export instructions
- describe how to fetch and update content via API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68449d6cf158832cbc695820ac0180b1