### PR TITLE
Atualiza doc do git-commit e versão do simple-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ Headers:
   "credentials": "ghp_xxx",
   "message": "feat: meu commit",
   "files": ["arquivo.txt"],
-  "branch": "main",
+  "branch": "main",  # opcional
   "content": {
-    "novo.txt": "conteudo gerado"
+  "novo.txt": "conteudo gerado"
   }
 }
 ```
 
-Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
+O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
 
 ---
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -96,6 +96,14 @@
       "post": {
         "operationId": "gitCommit",
         "description": "Realiza commit em repositório privado usando token",
+        "parameters": [
+          {
+            "name": "x-api-token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -210,7 +218,10 @@
             "type": "array",
             "items": { "type": "string" }
           },
-          "branch": { "type": "string" },
+          "branch": {
+            "type": "string",
+            "description": "Nome do branch (padr\u00e3o 'main')"
+          },
           "content": {
             "type": "object",
             "additionalProperties": { "type": "string" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "natural": "^8.1.0",
-        "simple-git": "^3.19.1",
+        "simple-git": "^3.28.0",
         "swagger-ui-express": "^4.6.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^5.1.0",
     "natural": "^8.1.0",
     "swagger-ui-express": "^4.6.3",
-    "simple-git": "^3.19.1"
+    "simple-git": "^3.28.0"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
## Summary
- documenta token na rota `/git-commit` no actions.json
- descreve que o campo `branch` é opcional no README
- atualiza `simple-git` para ^3.28.0

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68596d59c948832c9df0bc8f99ef4b00