### PR TITLE
Adicionar limpeza de tags órfãs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Headers:
 
 O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
 
+## 🧹 Endpoint para limpar tags órfãs
+
+Remove opções de tags não utilizadas em nenhuma página do banco.
+
+```http
+POST /limpar-tags-orfas
+
+{
+  "notion_token": "secret_xxx",
+  "nome_database": "Me Passa A Cola (GPT)"
+}
+```
+
+Retorna um resumo com a quantidade de tags removidas.
+
 ---
 
 ## ⚖️ Política de uso e privacidade

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -92,6 +92,21 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/limpar-tags-orfas": {
+      "post": {
+        "operationId": "limparTagsOrfas",
+        "description": "Remove tags não utilizadas do banco de dados.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/LimparTagsOrfas" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/git-commit": {
       "post": {
         "operationId": "gitCommit",
@@ -247,6 +262,20 @@
           }
         },
         "required": ["notion_token", "tema"]
+      },
+      "LimparTagsOrfas": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          }
+        },
+        "required": ["notion_token"]
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const {
     searchDatabaseByName,
     searchPageByTitle,
     limparTagsRuins,
+    removerTagsOrfas,
     getOrCreateTags,
     filterValidProperties,
     getOrCreatePage,
@@ -435,6 +436,27 @@ app.post("/atualizar-titulos-e-tags", async (req, res) => {
         }
 
         res.json({ ok: true, total: atualizadas.length, atualizadas });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.post('/limpar-tags-orfas', async (req, res) => {
+    try {
+        const {
+            notion_token,
+            nome_database = 'Me Passa A Cola (GPT)'
+        } = req.body;
+
+        if (!notion_token) return res.status(400).json({ error: 'Token do Notion é obrigatório.' });
+
+        const notion = new Client({ auth: notion_token });
+        const db = await searchDatabaseByName(notion, nome_database);
+        if (!db) return res.status(404).json({ error: 'Database não encontrado.' });
+
+        const resultado = await removerTagsOrfas(notion, db.id);
+        res.json({ ok: true, ...resultado });
     } catch (err) {
         console.error(err);
         res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- criar função `removerTagsOrfas` para excluir tags não utilizadas
- adicionar rota `POST /limpar-tags-orfas`
- documentar nova rota
- atualizar documentação de ações do GPT

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685df2e21c14832c9f1c58659064d5d8