### PR TITLE
Add Render deployment check workflow

### DIFF
--- a/.github/workflows/render-deploy-check.yml
+++ b/.github/workflows/render-deploy-check.yml
@@ -1,0 +1,21 @@
+name: Verificar Deploy no Render
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  check-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Esperar 45 segundos para estabilizar
+        run: sleep 45
+      - name: Fazer requisição ao app
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" https://me-passa-a-cola.onrender.com/api-docs)
+          if [ "$status" != "200" ]; then
+            echo "Aplicação não respondeu como esperado"
+            exit 1
+          fi
+


### PR DESCRIPTION
## Summary
- monitor Render deployment status in CI with a 45 second delay before the request

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68654a237e50832c82a7b102170883fd