### PR TITLE
Add Render deploy workflow doc

### DIFF
--- a/.github/workflows/render-deploy-check.yml
+++ b/.github/workflows/render-deploy-check.yml
@@ -1,0 +1,21 @@
+name: Verificar Deploy no Render
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  check-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Esperar 45 segundos para estabilizar
+        run: sleep 45
+      - name: Fazer requisição ao app
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" https://me-passa-a-cola.onrender.com/api-docs)
+          if [ "$status" != "200" ]; then
+            echo "Aplicação não respondeu como esperado"
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ POST /limpar-tags-orfas
 
 Retorna um resumo com a quantidade de tags removidas.
 
+## 🔍 Validação automática do deploy
+
+O repositório conta com um workflow do **GitHub Actions** que monitora se o
+deploy no Render está ativo. O arquivo
+`.github/workflows/render-deploy-check.yml` espera 45&nbsp;segundos antes de
+fazer uma requisição para `https://me-passa-a-cola.onrender.com/api-docs`. Se a
+resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
+produção.
+
 ---
 
 ## ⚖️ Política de uso e privacidade


### PR DESCRIPTION
## Summary
- document Render deploy check workflow in README

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68654a237e50832c82a7b102170883fd