### PR TITLE
Implementa integração Notion + Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,32 @@ Headers:
 
 O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
 
+## 🚀 Endpoint para Notion + Git
+
+Cria o conteúdo no Notion e salva o mesmo texto em um repositório Git.
+
+### Requisição
+
+```http
+POST /create-notion-content-git
+Headers:
+  x-api-token: <seu_token>
+
+{
+  "repoUrl": "https://github.com/usuario/repositorio.git",
+  "credentials": "ghp_xxx",
+  "commitMessage": "feat: novo conteúdo",
+  "filePath": "docs/novo.md",
+  "branch": "main",  # opcional
+  "notion_token": "secret_xxx",
+  "tema": "Matéria X",
+  "subtitulo": "Aula 1",
+  "resumo": "Conteúdo em Markdown"
+}
+```
+
+As tags informadas são combinadas com tags geradas automaticamente a partir do texto antes de criar a página e salvar o arquivo.
+
 ### 🔧 Variáveis de ambiente
 
 Antes de iniciar a API é preciso definir algumas variáveis no ambiente:

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -130,6 +130,29 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/create-notion-content-git": {
+      "post": {
+        "operationId": "criarNotionGit",
+        "description": "Cria p\u00e1gina no Notion e salva em reposit\u00f3rio Git.",
+        "parameters": [
+          {
+            "name": "x-api-token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/NotionContentGit" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/pdf-to-notion": {
       "post": {
         "operationId": "enviarPDF",
@@ -260,6 +283,29 @@
         "required": ["repoUrl", "credentials", "message"]
   },
 
+      "NotionContentGit": {
+        "type": "object",
+        "properties": {
+          "repoUrl": { "type": "string" },
+          "credentials": { "type": "string" },
+          "commitMessage": { "type": "string" },
+          "filePath": { "type": "string" },
+          "branch": { "type": "string" },
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integra\u00e7\u00e3o do Notion (ntn_...)"
+          },
+          "nome_database": { "type": "string" },
+          "tema": { "type": "string" },
+          "subtitulo": { "type": "string" },
+          "tipo": { "type": "string" },
+          "resumo": { "type": "string" },
+          "observacoes": { "type": "string" },
+          "tags": { "type": "string" },
+          "data": { "type": "string", "format": "date-time" }
+        },
+        "required": ["repoUrl", "credentials", "commitMessage", "filePath", "notion_token", "resumo"]
+      },
       "NotionPdf": {
         "type": "object",
         "properties": {

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -12,6 +12,8 @@ async function cloneRepo(repoUrl, credentials) {
 
     if (!fs.existsSync(repoPath)) {
         await git.clone(authUrl, repoPath);
+    } else {
+        await simpleGit(repoPath).pull();
     }
 
     return repoPath;


### PR DESCRIPTION
## Resumo
- adiciona novo endpoint `/create-notion-content-git` na definição de ações do GPT
- descreve schema `NotionContentGit` para envio conjunto ao Notion e Git

## Testes
- `npm test` *(falha: módulo `dotenv` ausente)*


------
https://chatgpt.com/codex/tasks/task_e_6866daeedaac832cb16cf18d81104600