### PR TITLE
Atualiza schema de cronograma

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Cria atividades de cronograma dentro de um tema.
 - `nome_database` (opcional)
 - `tema` (obrigatório)
 - `cronograma` (lista de `{ atividade, descricao?, data? }`)
-- `tags` (opcional)
+- `tags` (lista ou string, opcional)
 
 **Exemplo**
 
@@ -231,12 +231,24 @@ Cria atividades de cronograma dentro de um tema.
 POST /create-notion-cronograma
 {
   "notion_token": "secret_xxx",
+  "nome_database": "Me Passa A Cola (GPT)",
   "tema": "Matéria X",
   "cronograma": [
-    { "atividade": "Ler capítulo 1", "data": "2024-04-02" }
-  ]
+    {
+      "atividade": "Ler capítulo 1",
+      "descricao": "Leitura inicial",
+      "data": "2024-04-02"
+    }
+  ],
+  "tags": ["leitura", "cap1"],
+  "outrasProps": {
+    "Professor": { "rich_text": [{ "text": { "content": "Fulano" } }] }
+  }
 }
 ```
+
+É possível enviar outras propriedades do Notion no campo `outrasProps`, seguindo
+o formato aceito pela API.
 
 **Resposta**
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -219,22 +219,50 @@
           },
           "nome_database": {
             "type": "string",
-            "description": "Nome Da Base"
+            "description": "Nome do banco de dados. Padrão 'Me Passa A Cola (GPT)'"
           },
-          "tema": { "type": "string" },
+          "tema": {
+            "type": "string",
+            "description": "Tema ou página principal"
+          },
           "cronograma": {
             "type": "array",
+            "description": "Lista de atividades do cronograma",
             "items": {
               "type": "object",
               "properties": {
-                "atividade": { "type": "string" },
-                "descricao": { "type": "string" },
-                "data": { "type": "string", "format": "date-time" }
+                "atividade": {
+                  "type": "string",
+                  "description": "Título da atividade"
+                },
+                "descricao": {
+                  "type": "string",
+                  "description": "Descrição opcional da atividade"
+                },
+                "data": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Data ou horário da tarefa"
+                }
               },
               "required": ["atividade"]
             }
           },
-          "tags": { "type": "string" }
+          "tags": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              { "type": "string" }
+            ],
+            "description": "Lista de tags ou string separada por vírgulas"
+          },
+          "outrasProps": {
+            "type": "object",
+            "description": "Outras propriedades aceitas pelo Notion",
+            "additionalProperties": true
+          }
         },
         "required": ["tema", "cronograma", "notion_token"]
       },


### PR DESCRIPTION
## Resumo
- melhora descricao do schema `NotionCronograma`
- corrige tipo de `tags`
- adiciona campo `outrasProps`
- atualiza README com exemplo expandido

## Testes
- `npm test` *(falha: module dotenv nao encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686846ae6b60832c8b8980999afc649b