### PR TITLE
feat: suporte extra no cronograma

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,6 +214,34 @@ app.post('/create-notion-cronograma', async (req, res) => {
         const created = [];
         for (const item of cronograma) {
             if (!item.atividade) continue;
+
+            const extraProps = {
+                ...(item.tipoEvento !== undefined && {
+                    'Tipo de Evento': { select: { name: item.tipoEvento } }
+                }),
+                ...(item.participantes !== undefined && {
+                    Participantes: { rich_text: [{ text: { content: String(item.participantes) } }] }
+                }),
+                ...(item.prioridade !== undefined && {
+                    Prioridade: { select: { name: item.prioridade } }
+                }),
+                ...(item.lembrete !== undefined && {
+                    Lembrete: { rich_text: [{ text: { content: String(item.lembrete) } }] }
+                }),
+                ...(item.status !== undefined && {
+                    Status: { select: { name: item.status } }
+                }),
+                ...(item.notas !== undefined && {
+                    Notas: { rich_text: [{ text: { content: String(item.notas) } }] }
+                }),
+                ...(item.local !== undefined && {
+                    Local: { rich_text: [{ text: { content: String(item.local) } }] }
+                }),
+                ...(item.linkRelacionado !== undefined && {
+                    'Link Relacionado': { url: String(item.linkRelacionado) }
+                })
+            };
+
             const page = await getOrCreatePage({
                 notion,
                 databaseName: nome_database,
@@ -225,6 +253,7 @@ app.post('/create-notion-cronograma', async (req, res) => {
                 otherProps: {
                     ...(item.data && { Data: { date: { start: item.data } } }),
                     Tipo: { select: { name: 'Cronograma' } },
+                    ...extraProps,
                     ...outrasProps
                 }
             });


### PR DESCRIPTION
## Resumo
- extrai campos adicionais de cada item do cronograma
- inclui os novos campos em `otherProps` de forma opcional

## Testes
- `npm test` *(falhou: falta de dependências dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_686846acf7f8832cb8937e066f92accb