### PR TITLE
Add Doca integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ Crie um banco com os seguintes campos (com esses nomes e tipos):
 - Observacoes (Texto)
 - Tags (Multi-seleção)
 - Data (Data)
+
+## 📦 Integração com Doca
+
+Envie resumos e notas diretamente para a plataforma **Doca**.
+
+### Como usar
+
+1. Forneça seu **doca_token**.
+2. Opcionalmente defina a `baseUrl` da API.
+3. Chame o endpoint `/create-doca-content` com `tema`, `conteudo` e, se desejar, `tags`.
+
+**Exemplo**
+
+```http
+POST /create-doca-content
+{
+  "doca_token": "dk_xxx",
+  "tema": "Matéria X",
+  "conteudo": "Texto ou markdown",
+  "tags": ["exemplo"]
+}
+```
+
+Resposta:
+
+```json
+{ "ok": true }
+```
 ## 🚀 Como rodar localmente
 
 Para executar o projeto em sua máquina, siga os passos abaixo:

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -168,6 +168,21 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/create-doca-content": {
+      "post": {
+        "operationId": "enviarDoca",
+        "description": "Envia conteúdo para a plataforma Doca.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DocaContent" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/github-issues": {
       "post": {
         "operationId": "criarIssue",
@@ -488,6 +503,20 @@
             "repo": { "type": "string" }
           },
           "required": ["token", "owner", "repo"]
+        },
+        "DocaContent": {
+          "type": "object",
+          "properties": {
+            "doca_token": { "type": "string", "description": "Token da API Doca" },
+            "baseUrl": { "type": "string", "description": "URL base da API" },
+            "tema": { "type": "string" },
+            "conteudo": { "type": "string" },
+            "tags": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["doca_token", "tema", "conteudo"]
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const {
 } = require('./utils/notion');
 const { cloneRepo, commitAndPush } = require('./utils/git');
 const { createIssue, updateIssue, closeIssue, listIssues } = require('./utils/github');
+const { sendToDoca } = require('./utils/doca');
 const pdfParse = require('pdf-parse');
 const fs = require('fs');
 const path = require('path');
@@ -549,6 +550,20 @@ app.post('/limpar-tags-orfas', async (req, res) => {
 
         const resultado = await removerTagsOrfas(notion, db.id);
         res.json({ ok: true, ...resultado });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.post('/create-doca-content', async (req, res) => {
+    try {
+        const { doca_token, baseUrl, tema, conteudo, tags = [] } = req.body;
+        if (!doca_token) return res.status(400).json({ error: 'Token da Doca é obrigatório.' });
+        if (!tema || !conteudo) return res.status(400).json({ error: 'Tema e conteúdo são obrigatórios.' });
+
+        const response = await sendToDoca({ doca_token, baseUrl, data: { tema, conteudo, tags } });
+        res.json({ ok: true, response });
     } catch (err) {
         console.error(err);
         res.status(500).json({ error: err.message });

--- a/src/utils/doca.js
+++ b/src/utils/doca.js
@@ -1,0 +1,16 @@
+async function sendToDoca({ doca_token, baseUrl = 'https://api.doca.com', data }) {
+  const res = await fetch(`${baseUrl}/conteudos`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${doca_token}`
+    },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    throw new Error(`Doca API error: ${res.status}`);
+  }
+  return res.json();
+}
+
+module.exports = { sendToDoca };

--- a/tests/run.js
+++ b/tests/run.js
@@ -16,6 +16,14 @@ async function main() {
   });
 
   assert.strictEqual(res.status, 400);
+
+  const resDoca = await fetch(`http://localhost:${port}/create-doca-content`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({})
+  });
+
+  assert.strictEqual(resDoca.status, 400);
   server.close();
 
   await testCloneRepoPull();


### PR DESCRIPTION
## Summary
- create Doca utility
- expose `/create-doca-content` endpoint
- document Doca integration in README
- describe new endpoint in actions.json
- test missing parameters

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa55a2f8832ca468db21db74d835