### PR TITLE
Adicionar integração com Doca

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ O GPT foi desenvolvido para:
 * **Sugestões de técnicas de estudo** (Pomodoro, Cornell, repetição espaçada)
 * **Recomendações de conteúdos extras** (vídeos, livros, podcasts)
 * **Flashcards automáticos**
+* **Envio de conteúdos para o Doca**
 
 ---
 
@@ -113,6 +114,10 @@ Crie um banco com os seguintes campos (com esses nomes e tipos):
 - Observacoes (Texto)
 - Tags (Multi-seleção)
 - Data (Data)
+
+## 🔗 Integração com Doca
+
+Configure as variáveis `DOCA_API_URL` e `DOCA_API_KEY` para permitir o envio de conteúdos ao serviço Doca.
 ## 🚀 Como rodar localmente
 
 Para executar o projeto em sua máquina, siga os passos abaixo:
@@ -458,6 +463,19 @@ DELETE /github-issues/{numero}
 
 ```http
 GET /github-issues?token=ghp_xxx&owner=usuario&repo=repositorio&state=open
+```
+
+## 📑 Endpoint para Doca
+
+Permite enviar conteúdos diretamente para o serviço **Doca**.
+
+```http
+POST /send-to-doca
+
+{
+  "title": "Meu arquivo",
+  "content": "Texto em Markdown"
+}
 ```
 
 ## 🔍 Validação automática do deploy

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -168,6 +168,21 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/send-to-doca": {
+      "post": {
+        "operationId": "enviarDoca",
+        "description": "Envia conteúdo para o serviço Doca.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DocaContent" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/github-issues": {
       "post": {
         "operationId": "criarIssue",
@@ -488,6 +503,14 @@
             "repo": { "type": "string" }
           },
           "required": ["token", "owner", "repo"]
+        },
+        "DocaContent": {
+          "type": "object",
+          "properties": {
+            "title": { "type": "string" },
+            "content": { "type": "string" }
+          },
+          "required": ["title", "content"]
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const {
 } = require('./utils/notion');
 const { cloneRepo, commitAndPush } = require('./utils/git');
 const { createIssue, updateIssue, closeIssue, listIssues } = require('./utils/github');
+const { sendToDoca } = require('./utils/doca');
 const pdfParse = require('pdf-parse');
 const fs = require('fs');
 const path = require('path');
@@ -739,6 +740,21 @@ app.get('/github-issues', async (req, res) => {
     try {
         const issues = await listIssues({ token, owner, repo, state, labels });
         res.json({ ok: true, issues });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// ----- Integração com Doca -----
+app.post('/send-to-doca', async (req, res) => {
+    try {
+        const { title, content } = req.body;
+        if (!title || !content) {
+            return res.status(400).json({ error: 'title e content são obrigatórios' });
+        }
+        const result = await sendToDoca({ title, content });
+        res.json({ ok: true, result });
     } catch (err) {
         console.error(err);
         res.status(500).json({ error: err.message });

--- a/src/utils/doca.js
+++ b/src/utils/doca.js
@@ -1,0 +1,25 @@
+async function sendToDoca(data) {
+  const url = process.env.DOCA_API_URL;
+  const key = process.env.DOCA_API_KEY;
+  if (!url) throw new Error('DOCA_API_URL nao definido');
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { 'Authorization': `Bearer ${key}` } : {})
+    },
+    body: JSON.stringify(data)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Erro DOCA: ${text}`);
+  }
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+module.exports = { sendToDoca };


### PR DESCRIPTION
## Resumo
- nova função `sendToDoca` para envio de dados
- endpoint `/send-to-doca` na API
- documentação sobre a integração e novo endpoint
- Swagger atualizado com rota e schema `DocaContent`

## Testes
- `npm test` *(falhou: módulo dotenv ausente)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa55a2f8832ca468db21db74d835