### PR TITLE
Adicionar endpoints de workflow do GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,26 @@ DELETE /github-issues/{numero}
 GET /github-issues?token=ghp_xxx&owner=usuario&repo=repositorio&state=open
 ```
 
+### Disparar Workflow
+
+```http
+POST /github-workflows/dispatch
+
+{
+  "token": "ghp_xxx",
+  "owner": "usuario",
+  "repo": "repositorio",
+  "workflow_id": "deploy.yml",
+  "ref": "main"
+}
+```
+
+### Verificar Status do Workflow
+
+```http
+GET /github-workflows/status?token=ghp_xxx&owner=usuario&repo=repositorio&run_id=12345
+```
+
 ## 🔍 Validação automática do deploy
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -210,6 +210,30 @@
         },
         "responses": { "200": { "description": "Sucesso" } }
       }
+    },
+    "/github-workflows/dispatch": {
+      "post": {
+        "operationId": "dispararWorkflow",
+        "description": "Dispara um workflow no GitHub",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GithubWorkflowDispatch" } } }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
+    "/github-workflows/status": {
+      "get": {
+        "operationId": "statusWorkflow",
+        "description": "Consulta o status de um workflow run",
+        "parameters": [
+          { "name": "token", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "owner", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "repo", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "run_id", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Sucesso" } }
+      }
     }
   },
   "components": {
@@ -488,6 +512,18 @@
             "repo": { "type": "string" }
           },
           "required": ["token", "owner", "repo"]
+        },
+        "GithubWorkflowDispatch": {
+          "type": "object",
+          "properties": {
+            "token": { "type": "string" },
+            "owner": { "type": "string" },
+            "repo": { "type": "string" },
+            "workflow_id": { "type": "string" },
+            "ref": { "type": "string", "default": "main" },
+            "inputs": { "type": "object" }
+          },
+          "required": ["token", "owner", "repo", "workflow_id"]
         }
       }
     }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -41,4 +41,15 @@ async function listIssues({ token, owner, repo, state = 'open', labels = '' }) {
     return githubRequest(token, 'GET', `/repos/${owner}/${repo}/issues?${searchParams.toString()}`);
 }
 
-module.exports = { createIssue, updateIssue, closeIssue, listIssues };
+async function dispatchWorkflow({ token, owner, repo, workflow_id, ref = 'main', inputs = {} }) {
+    return githubRequest(token, 'POST', `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`, {
+        ref,
+        inputs
+    });
+}
+
+async function getWorkflowRun({ token, owner, repo, run_id }) {
+    return githubRequest(token, 'GET', `/repos/${owner}/${repo}/actions/runs/${run_id}`);
+}
+
+module.exports = { createIssue, updateIssue, closeIssue, listIssues, dispatchWorkflow, getWorkflowRun };


### PR DESCRIPTION
## Resumo
- implementar funções dispatchWorkflow e getWorkflowRun
- expor novos endpoints REST para iniciar e verificar workflows
- documentar as rotas no Swagger (actions.json)
- atualizar README com exemplos de uso

## Testes
- `npm test` *(falhou: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8e5078832ca3a018669c6ffbb0