### PR TITLE
Add Doca integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,11 @@ POST /github-workflows/dispatch
 GET /github-workflows/status?token=ghp_xxx&owner=usuario&repo=repositorio&run_id=12345
 ```
 
+## 📚 Documentação com Doca
+
+Execute `npm run doca` para gerar a documentação da API em `docs/API.md`.
+Depois de iniciar o servidor, acesse `http://localhost:3333/doca/API.md` para visualizar.
+
 ## 🔍 Validação automática do deploy
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,62 @@
+# API
+
+## POST /create-notion-content
+
+Envia o conteúdo dos resumos Notion informados no corpo.
+
+## POST /create-notion-flashcards
+
+Envia o conteúdo dos flashcards Notion informados no corpo.
+
+## POST /create-notion-cronograma
+
+Envia itens de cronograma para o Notion.
+
+## GET /notion-content
+
+Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.
+
+## POST /atualizar-titulos-e-tags
+
+Atualiza títulos e tags das subpáginas de um tema no Notion.
+
+## POST /limpar-tags-orfas
+
+Remove tags não utilizadas do banco de dados.
+
+## POST /git-commit
+
+Realiza commit em repositório privado usando token
+
+## POST /create-notion-content-git
+
+Cria página no Notion e salva em repositório Git.
+
+## POST /pdf-to-notion
+
+Envia um PDF em base64 para conversão em Markdown e registro no Notion.
+
+## POST /github-issues
+
+Cria uma issue no GitHub
+
+## GET /github-issues
+
+Lista issues do repositório
+
+## PATCH /github-issues/{number}
+
+Atualiza uma issue existente
+
+## DELETE /github-issues/{number}
+
+Fecha uma issue
+
+## POST /github-workflows/dispatch
+
+Dispara um workflow no GitHub
+
+## GET /github-workflows/status
+
+Consulta o status de um workflow run
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node tests/run.js"
+    "test": "node tests/run.js",
+    "doca": "node src/doca.js"
   },
   "keywords": [],
   "author": "",

--- a/src/doca.js
+++ b/src/doca.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const spec = require('../gpt/actions.json');
+
+function generateDocs() {
+  let md = `# API\n\n`;
+  for (const [route, methods] of Object.entries(spec.paths)) {
+    for (const [verb, info] of Object.entries(methods)) {
+      md += `## ${verb.toUpperCase()} ${route}\n\n`;
+      if (info.description) {
+        md += info.description + '\n\n';
+      }
+    }
+  }
+  return md;
+}
+
+function main() {
+  const docsDir = path.join(__dirname, '..', 'docs');
+  if (!fs.existsSync(docsDir)) fs.mkdirSync(docsDir);
+  const md = generateDocs();
+  fs.writeFileSync(path.join(docsDir, 'API.md'), md);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { generateDocs };

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ const API_TOKEN = process.env.API_TOKEN || '';
 app.use(express.json());
 // Expose Swagger documentation
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+// Documentação estática gerada com Doca
+app.use('/doca', express.static(path.join(__dirname, '..', 'docs')));
 
 // Endpoint principal
 app.post("/create-notion-content", async (req, res) => {


### PR DESCRIPTION
## Summary
- generate static API docs with a new `doca` script
- serve the generated docs in `/doca`
- document usage in README

## Testing
- `npm run doca`
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6869b532a1bc832ca35a6587d76b37d4