### PR TITLE
Add separate actions specs and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,15 @@ GET /github-workflows/status?token=ghp_xxx&owner=usuario&repo=repositorio&run_id
 Execute `npm run doca` para gerar a documentação da API em `docs/API.md`.
 Depois de iniciar o servidor, acesse `http://localhost:3333/doca/API.md` para visualizar.
 
+### Ações para GPT personalizado
+
+Os endpoints foram divididos em dois arquivos dentro de `gpt/`:
+
+- `actions-notion.json` – somente rotas relacionadas ao Notion;
+- `actions-github.json` – rotas de integrações com o GitHub.
+
+Ao criar seu GPT, envie um ou ambos os arquivos na etapa de **Actions** para habilitar as funcionalidades desejadas.
+
 ## 🔍 Validação automática do deploy
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,61 @@
 # API
 
+## POST /github-issues
+
+Cria uma issue no GitHub
+
+## GET /github-issues
+
+Lista issues do repositório
+
+## PATCH /github-issues/{number}
+
+Atualiza uma issue existente
+
+## DELETE /github-issues/{number}
+
+Fecha uma issue
+
+## POST /github-workflows/dispatch
+
+Dispara um workflow no GitHub
+
+## GET /github-workflows/status
+
+Consulta o status de um workflow run
+
+## POST /github-labels
+
+Cria uma label no repositório
+
+## POST /github-milestones
+
+Cria uma milestone
+
+## POST /github-projects
+
+Cria um projeto classic
+
+## POST /github-projects/{project_id}/columns
+
+Cria coluna em um projeto
+
+## POST /github-projects/columns/{column_id}/cards
+
+Adiciona issue ao projeto
+
+## POST /github-pulls
+
+Cria um pull request
+
+## PATCH /github-pulls/{number}
+
+Atualiza um pull request
+
+## DELETE /github-pulls/{number}
+
+Fecha um pull request
+
 ## POST /create-notion-content
 
 Envia o conteúdo dos resumos Notion informados no corpo.
@@ -24,39 +80,15 @@ Atualiza títulos e tags das subpáginas de um tema no Notion.
 
 Remove tags não utilizadas do banco de dados.
 
-## POST /git-commit
+## POST /pdf-to-notion
 
-Realiza commit em repositório privado usando token
+Envia um PDF em base64 para conversão em Markdown e registro no Notion.
 
 ## POST /create-notion-content-git
 
 Cria página no Notion e salva em repositório Git.
 
-## POST /pdf-to-notion
+## POST /git-commit
 
-Envia um PDF em base64 para conversão em Markdown e registro no Notion.
-
-## POST /github-issues
-
-Cria uma issue no GitHub
-
-## GET /github-issues
-
-Lista issues do repositório
-
-## PATCH /github-issues/{number}
-
-Atualiza uma issue existente
-
-## DELETE /github-issues/{number}
-
-Fecha uma issue
-
-## POST /github-workflows/dispatch
-
-Dispara um workflow no GitHub
-
-## GET /github-workflows/status
-
-Consulta o status de um workflow run
+Realiza commit em repositório privado usando token
 

--- a/gpt/actions-github.json
+++ b/gpt/actions-github.json
@@ -1,0 +1,725 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Enviar Conteúdo de Estudo",
+    "description": "Envia conteúdo de estudo para o banco do Notion, com dados de destino informados no corpo da requisição.",
+    "version": "v1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://me-passa-a-cola.onrender.com"
+    }
+  ],
+  "paths": {
+    "/github-issues": {
+      "post": {
+        "operationId": "criarIssue",
+        "description": "Cria uma issue no GitHub",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubIssueCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      },
+      "get": {
+        "operationId": "listarIssues",
+        "description": "Lista issues do repositório",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repo",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "open"
+            }
+          },
+          {
+            "name": "labels",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-issues/{number}": {
+      "patch": {
+        "operationId": "atualizarIssue",
+        "description": "Atualiza uma issue existente",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubIssueUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "fecharIssue",
+        "description": "Fecha uma issue",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubIssueDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-workflows/dispatch": {
+      "post": {
+        "operationId": "dispararWorkflow",
+        "description": "Dispara um workflow no GitHub",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubWorkflowDispatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-workflows/status": {
+      "get": {
+        "operationId": "statusWorkflow",
+        "description": "Consulta o status de um workflow run",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repo",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-labels": {
+      "post": {
+        "operationId": "criarLabel",
+        "description": "Cria uma label no repositório",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubLabelCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-milestones": {
+      "post": {
+        "operationId": "criarMilestone",
+        "description": "Cria uma milestone",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubMilestoneCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-projects": {
+      "post": {
+        "operationId": "criarProjeto",
+        "description": "Cria um projeto classic",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubProjectCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-projects/{project_id}/columns": {
+      "post": {
+        "operationId": "criarColunaProjeto",
+        "description": "Cria coluna em um projeto",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubProjectColumnCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-projects/columns/{column_id}/cards": {
+      "post": {
+        "operationId": "adicionarIssueProjeto",
+        "description": "Adiciona issue ao projeto",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubProjectCardCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-pulls": {
+      "post": {
+        "operationId": "criarPullRequest",
+        "description": "Cria um pull request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubPullCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/github-pulls/{number}": {
+      "patch": {
+        "operationId": "atualizarPullRequest",
+        "description": "Atualiza um pull request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubPullUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "fecharPullRequest",
+        "description": "Fecha um pull request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GithubPullDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GithubIssueCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "labels": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "assignees": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "title"
+        ]
+      },
+      "GithubIssueUpdate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "labels": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "assignees": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo"
+        ]
+      },
+      "GithubIssueDelete": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo"
+        ]
+      },
+      "GithubWorkflowDispatch": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "workflow_id": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string",
+            "default": "main"
+          },
+          "inputs": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "workflow_id"
+        ]
+      },
+      "GithubLabelCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "name"
+        ]
+      },
+      "GithubMilestoneCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "due_on": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "title"
+        ]
+      },
+      "GithubProjectCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "name"
+        ]
+      },
+      "GithubProjectColumnCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "project_id",
+          "name"
+        ]
+      },
+      "GithubProjectCardCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "column_id": {
+            "type": "string"
+          },
+          "issue_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "token",
+          "column_id",
+          "issue_id"
+        ]
+      },
+      "GithubPullCreate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "head": {
+            "type": "string"
+          },
+          "base": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo",
+          "title",
+          "head",
+          "base"
+        ]
+      },
+      "GithubPullUpdate": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo"
+        ]
+      },
+      "GithubPullDelete": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "owner",
+          "repo"
+        ]
+      }
+    }
+  }
+}

--- a/gpt/actions-notion.json
+++ b/gpt/actions-notion.json
@@ -1,0 +1,547 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Enviar Conteúdo de Estudo",
+    "description": "Envia conteúdo de estudo para o banco do Notion, com dados de destino informados no corpo da requisição.",
+    "version": "v1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://me-passa-a-cola.onrender.com"
+    }
+  ],
+  "paths": {
+    "/create-notion-content": {
+      "post": {
+        "operationId": "enviarResumos",
+        "description": "Envia o conteúdo dos resumos Notion informados no corpo.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotionContent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/create-notion-flashcards": {
+      "post": {
+        "operationId": "enviarFlashcards",
+        "description": "Envia o conteúdo dos flashcards Notion informados no corpo.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotionFlashcards"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/create-notion-cronograma": {
+      "post": {
+        "operationId": "enviarCronograma",
+        "description": "Envia itens de cronograma para o Notion.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotionCronograma"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/notion-content": {
+      "get": {
+        "operationId": "buscarConteudoNotion",
+        "description": "Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.",
+        "parameters": [
+          {
+            "name": "notion_token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nome_database",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tema",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subtitulo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tipo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/atualizar-titulos-e-tags": {
+      "post": {
+        "operationId": "atualizarTitulosETags",
+        "description": "Atualiza títulos e tags das subpáginas de um tema no Notion.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTitulosETags"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/limpar-tags-orfas": {
+      "post": {
+        "operationId": "limparTagsOrfas",
+        "description": "Remove tags não utilizadas do banco de dados.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LimparTagsOrfas"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/pdf-to-notion": {
+      "post": {
+        "operationId": "enviarPDF",
+        "description": "Envia um PDF em base64 para conversão em Markdown e registro no Notion.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotionPdf"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    },
+    "/create-notion-content-git": {
+      "post": {
+        "operationId": "criarNotionGit",
+        "description": "Cria página no Notion e salva em repositório Git.",
+        "parameters": [
+          {
+            "name": "x-api-token",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotionContentGit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NotionContent": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          },
+          "tema": {
+            "type": "string"
+          },
+          "subtitulo": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": "string"
+          },
+          "resumo": {
+            "type": "string"
+          },
+          "observacoes": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "destino": {
+            "type": "string",
+            "description": "Destino do envio: 'notion'",
+            "enum": [
+              "notion"
+            ]
+          }
+        },
+        "required": [
+          "destino",
+          "tema",
+          "resumo"
+        ]
+      },
+      "NotionFlashcards": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          },
+          "tema": {
+            "type": "string"
+          },
+          "subtitulo": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": "string"
+          },
+          "flashcards": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "pergunta": {
+                  "type": "string"
+                },
+                "resposta": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pergunta",
+                "resposta"
+              ]
+            }
+          },
+          "observacoes": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "destino": {
+            "type": "string",
+            "description": "Destino do envio: 'notion'",
+            "enum": [
+              "notion"
+            ]
+          }
+        },
+        "required": [
+          "destino",
+          "tema",
+          "flashcards"
+        ]
+      },
+      "NotionCronograma": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome do banco de dados. Padrão 'Me Passa A Cola (GPT)'"
+          },
+          "tema": {
+            "type": "string",
+            "description": "Tema ou página principal"
+          },
+          "cronograma": {
+            "type": "array",
+            "description": "Lista de atividades do cronograma",
+            "items": {
+              "type": "object",
+              "properties": {
+                "atividade": {
+                  "type": "string",
+                  "description": "Título da atividade"
+                },
+                "descricao": {
+                  "type": "string",
+                  "description": "Descrição opcional da atividade"
+                },
+                "data": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Data ou horário da tarefa"
+                }
+              },
+              "required": [
+                "atividade"
+              ]
+            }
+          },
+          "tags": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Lista de tags ou string separada por vírgulas"
+          },
+          "outrasProps": {
+            "type": "object",
+            "description": "Outras propriedades aceitas pelo Notion",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "tema",
+          "cronograma",
+          "notion_token"
+        ]
+      },
+      "NotionContentGit": {
+        "type": "object",
+        "properties": {
+          "repoUrl": {
+            "type": "string"
+          },
+          "credentials": {
+            "type": "string"
+          },
+          "commitMessage": {
+            "type": "string"
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string"
+          },
+          "tema": {
+            "type": "string"
+          },
+          "subtitulo": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": "string"
+          },
+          "resumo": {
+            "type": "string"
+          },
+          "observacoes": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "repoUrl",
+          "credentials",
+          "commitMessage",
+          "filePath",
+          "notion_token",
+          "resumo"
+        ]
+      },
+      "NotionPdf": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          },
+          "tema": {
+            "type": "string"
+          },
+          "subtitulo": {
+            "type": "string"
+          },
+          "pdf_base64": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "destino": {
+            "type": "string",
+            "description": "Destino do envio: 'notion'",
+            "enum": [
+              "notion"
+            ]
+          }
+        },
+        "required": [
+          "destino",
+          "pdf_base64"
+        ]
+      },
+      "AtualizarTitulosETags": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          },
+          "tema": {
+            "type": "string",
+            "description": "Tema cujas subpáginas devem ser atualizadas"
+          }
+        },
+        "required": [
+          "notion_token",
+          "tema"
+        ]
+      },
+      "LimparTagsOrfas": {
+        "type": "object",
+        "properties": {
+          "notion_token": {
+            "type": "string",
+            "description": "Token da integração do Notion (ntn_...)"
+          },
+          "nome_database": {
+            "type": "string",
+            "description": "Nome Da Base"
+          }
+        },
+        "required": [
+          "notion_token"
+        ]
+      }
+    }
+  }
+}

--- a/src/doca.js
+++ b/src/doca.js
@@ -1,6 +1,21 @@
 const fs = require('fs');
 const path = require('path');
-const spec = require('../gpt/actions.json');
+const gptDir = path.join(__dirname, '..', 'gpt');
+const specs = fs.readdirSync(gptDir)
+  .filter(f => /^actions.*\.json$/.test(f))
+  .map(f => JSON.parse(fs.readFileSync(path.join(gptDir, f), 'utf8')));
+const spec = specs.reduce((base, s) => {
+  if (!base) return { ...s };
+  Object.assign(base.paths, s.paths);
+  if (s.components && s.components.schemas) {
+    base.components = base.components || { schemas: {} };
+    base.components.schemas = {
+      ...base.components.schemas,
+      ...s.components.schemas,
+    };
+  }
+  return base;
+}, null);
 
 function generateDocs() {
   let md = `# API\n\n`;

--- a/tests/run.js
+++ b/tests/run.js
@@ -16,6 +16,12 @@ async function main() {
   });
 
   assert.strictEqual(res.status, 400);
+
+  const specRes = await fetch(`http://localhost:${port}/api-docs.json`);
+  assert.strictEqual(specRes.status, 200);
+  const spec = await specRes.json();
+  assert(spec.paths['/create-notion-content']);
+  assert(spec.paths['/github-issues']);
   server.close();
 
   await testCloneRepoPull();


### PR DESCRIPTION
## Summary
- split Notion and GitHub endpoints into `gpt/actions-notion.json` and `gpt/actions-github.json`
- load all `actions*.json` files automatically in Swagger and Doca
- serve OpenAPI JSON at `/api-docs.json`
- document how to use the new files for GPT configuration
- test merged spec via new endpoint

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm run doca`

------
https://chatgpt.com/codex/tasks/task_e_686ac4b1bfd0832cb52b0d0831421a60