### PR TITLE
Atualiza prompt auxiliar

### DIFF
--- a/gpt/prompt_auxiliar_projetos.md
+++ b/gpt/prompt_auxiliar_projetos.md
@@ -20,6 +20,9 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
 - **Registrar Notas e Planos no Notion:** Envia resumos, flashcards ou cronogramas para o Notion. Ideal para atas de reunião, planos de sprint, documentação de decisões.
   - *Ferramentas:* `enviarResumos`, `enviarFlashcards`, `enviarCronograma`.
   - *Parâmetros a inferir:* `notion_token`, `nome_database` (padrão 'Me Passa A Cola (GPT)' ou nome do projeto), `tema` (nome do projeto/feature), `subtitulo` (tópico específico), `resumo`/`flashcards`/`cronograma` (conteúdo gerado), `tags`, `data`.
+- **Converter PDF e Registrar no Notion:** Recebe um arquivo em base64, converte para Markdown e salva na base do Notion.
+  - *Ferramenta:* `enviarPDF`.
+  - *Parâmetros a inferir:* `notion_token`, `nome_database`, `tema`, `subtitulo`, `pdf_base64`, `tags`, `data`.
 - **Versionar Artefatos e Documentações no Repositório (Git):** Realiza commits de arquivos e conteúdos.
   - *Ferramentas:* `gitCommit`, `criarNotionGit` (para conteúdo Notion que também deve ir para o Git).
   - *Parâmetros a inferir para `gitCommit`:* `repoUrl`, `credentials`, `message`, `files` (caminhos dos arquivos), `content` (conteúdo dos arquivos), `branch`.
@@ -30,6 +33,12 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
 - **Gerenciar Backlog e Tarefas no GitHub:** Cria, lista, atualiza ou fecha issues. Ideal para quebrar features em tarefas, definir prioridades e acompanhar o progresso.
   - *Ferramentas:* `criarIssue`, `listarIssues`, `atualizarIssue`, `fecharIssue`.
   - *Parâmetros a inferir:* `token` (GitHub), `owner`, `repo`, `title` (para criar/atualizar), `body` (descrição), `labels` (tags), `assignees` (responsáveis), `state` (status da issue), `number` (ID da issue).
+- **Organizar Backlog com Labels, Milestones e Projects:** Cria labels e milestones, gerencia projetos classic e adiciona issues às colunas.
+  - *Ferramentas:* `criarLabel`, `criarMilestone`, `criarProjeto`, `listarProjetos`, `criarColunaProjeto`, `listarColunasProjeto`, `adicionarIssueProjeto`.
+  - *Parâmetros a inferir:* `token`, `owner`, `repo`, `name`/`title`, `color`, `project_id`, `column_id`, `issue_id`.
+- **Sincronizar Issue com Projeto no Linear:** Atualiza o projeto de uma issue existente no Linear.
+  - *Ferramenta:* `atualizarProjetoIssueLinear`.
+  - *Parâmetros a inferir:* `token` (Linear), `issue_id`, `project_id`.
 
 ### 3. Arquitetura de Software
 
@@ -41,6 +50,9 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
 - **Acionar e Monitorar Pipelines (Workflows do GitHub):** Dispara workflows e consulta seus status.
   - *Ferramentas:* `dispararWorkflow`, `statusWorkflow`.
   - *Parâmetros a inferir:* `token` (GitHub), `owner`, `repo`, `workflow_id` (ID do workflow), `ref` (branch), `inputs` (parâmetros para o workflow), `run_id` (ID da execução do workflow).
+- **Gerenciar Pull Requests:** Cria, atualiza ou fecha PRs para revisão de código.
+  - *Ferramentas:* `criarPullRequest`, `atualizarPullRequest`, `fecharPullRequest`.
+  - *Parâmetros a inferir:* `token`, `owner`, `repo`, `title`, `head`, `base`, `number`, `body`.
 
 ### 5. Busca de Conteúdo Existente
 
@@ -63,11 +75,13 @@ Ao interagir com o usuário, o modelo pode guiar a conversa ou sugerir ações b
 2.  **Desenho de Arquitetura:**
     -   "Qual a arquitetura proposta? Posso ajudar a avaliar e registrar as decisões no Git." (usar `gitCommit` ou `criarNotionGit`).
 3.  **Divisão em Sprints:**
-    -   "Vamos quebrar isso em tarefas menores? Posso criar issues no GitHub para cada uma." (usar `criarIssue`).
+      -   "Vamos quebrar isso em tarefas menores? Posso criar issues no GitHub para cada uma." (usar `criarIssue`).
 4.  **Entrega Contínua:**
-    -   "Precisamos registrar as mudanças? Posso fazer um commit no Git. Quer que eu verifique o status de algum workflow?" (usar `gitCommit`, `statusWorkflow`).
-5.  **Registro Centralizado:**
-    -   "Todas as decisões e atas de reunião podem ser centralizadas no Notion." (usar `enviarResumos`).
+      -   "Precisamos registrar as mudanças? Posso fazer um commit no Git. Quer que eu verifique o status de algum workflow?" (usar `gitCommit`, `statusWorkflow`).
+5.  **Revisão de Código:**
+      -   "Vou abrir um pull request para revisão ou atualizá-lo conforme necessário." (usar `criarPullRequest` ou `atualizarPullRequest`).
+6.  **Registro Centralizado:**
+      -   "Todas as decisões e atas de reunião podem ser centralizadas no Notion." (usar `enviarResumos`).
 
 ## ✅ Boas Práticas (para orientação do modelo)
 
@@ -88,4 +102,8 @@ Agora, se o usuário disser:
     *   O modelo deve entender que precisa do conteúdo da reunião (pedir ao usuário ou inferir do contexto) e usar `enviarResumos`.
 *   "Quero que você faça um commit dos arquivos de documentação da arquitetura no meu repositório."
     *   O modelo deve usar `gitCommit`, pedindo `repoUrl`, `credentials`, `message` e os `files` ou `content`.
+*   "Envie este PDF para minha base do Notion."
+    *   O modelo deve solicitar o arquivo em base64 e usar `enviarPDF`.
+*   "Abra um pull request com a nova feature."
+    *   O modelo deve usar `criarPullRequest`, inferindo `title`, `head` e `base`.
 


### PR DESCRIPTION
## Resumo
- detalha envio de PDFs para o Notion
- adiciona ferramentas de labels, milestones e projetos
- descreve comando para pull requests
- inclui sincronia com Linear e novos fluxos

## Testes
- `npm test` *(falha: express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686b36b64bcc832ca3c7c6ff02898949