### PR TITLE
Add GraphQL error handling

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -80,6 +80,9 @@ Lista projetos do repositório
 
 Cria coluna em um projeto via GraphQL
 
+> **Nota**: se a resposta do GitHub contiver `errors`, o serviço retorna
+> a mensagem de erro fornecida pela API.
+
 ## GET /github-projects/{project_id}/columns
 
 Lista colunas de um projeto

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -11,11 +11,15 @@ async function githubGraphqlRequest(token, query, variables = {}) {
         },
         body: JSON.stringify({ query, variables })
     });
+    const data = await res.json();
     if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`GitHub GraphQL ${res.status}: ${text}`);
+        throw new Error(`GitHub GraphQL ${res.status}: ${JSON.stringify(data)}`);
     }
-    return await res.json();
+    if (data.errors) {
+        const msg = data.errors.map(e => e.message).join('; ');
+        throw new Error(msg);
+    }
+    return data;
 }
 
 async function githubRequest(token, method, url, body, extraHeaders = {}) {


### PR DESCRIPTION
## Summary
- add error check on GraphQL responses in `githubGraphqlRequest`
- document new behavior about GraphQL errors

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686c00d71ca0832cae83516cae924795