### PR TITLE
Add deploy check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,14 @@ fazer uma requisição para `https://me-passa-a-cola.onrender.com/api-docs`. Se 
 resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
 produção.
 
+Para testar manualmente, rode:
+
+```bash
+node scripts/check-deploy.js [URL]
+```
+
+O script retorna código diferente de zero caso a URL não responda com `200`.
+
 ---
 
 ## ⚖️ Política de uso e privacidade

--- a/scripts/check-deploy.js
+++ b/scripts/check-deploy.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const url = process.argv[2] || 'https://me-passa-a-cola.onrender.com/api-docs';
+
+async function main() {
+  try {
+    const res = await fetch(url);
+    if (res.status === 200) {
+      console.log(`OK: ${url} retornou 200`);
+      process.exit(0);
+    } else {
+      console.error(`ERRO: ${url} retornou ${res.status}`);
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`Falha ao acessar ${url}:`, err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to verify that `/api-docs` endpoint is responding
- document how to run the deploy check

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686c1583c488832c9f5ed7f1c5dab777