### PR TITLE
Atualiza README com novo nome do workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ as integrações disponíveis.
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o
 deploy no Render está ativo. O arquivo
-`.github/workflows/render-deploy-check.yml` espera 45&nbsp;segundos antes de
+`.github/workflows/render-deploy-and-check.yml` espera 45&nbsp;segundos antes de
 fazer uma requisição para `https://me-passa-a-cola.onrender.com/api-docs`. Se a
 resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
 produção.


### PR DESCRIPTION
## Resumo
- ajusta referência ao workflow de deploy no README

## Testes
- `npm test` *(falhou: módulo 'express' ausente)*

------
https://chatgpt.com/codex/tasks/task_e_686c2143030c832ca21fdc9eff2dcd1d