### PR TITLE
Atualizar verificação de deploy

### DIFF
--- a/.github/workflows/render-deploy-and-check.yml
+++ b/.github/workflows/render-deploy-and-check.yml
@@ -15,6 +15,8 @@ jobs:
   deploy-and-check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Instalar Render CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh
@@ -29,12 +31,11 @@ jobs:
       - name: Aguardar estabilização (60s)
         run: sleep 60
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       - name: Verificar status da aplicação
         run: |
-          status=$(curl -s -o /dev/null -w "%{http_code}" https://me-passa-a-cola.onrender.com/api-docs)
-          if [ "$status" != "200" ]; then
-            echo "Aplicação não respondeu corretamente. Status HTTP: $status"
-            exit 1
-          else
-            echo "Deploy concluído com sucesso. Aplicação respondeu com HTTP 200."
-          fi
+          npm ci
+          node scripts/check-deploy.js


### PR DESCRIPTION
## Resumo
- acionar `actions/checkout` e `actions/setup-node`
- usar `node scripts/check-deploy.js` em vez de `curl`
- instalar dependências com `npm ci`

## Issue
- refs #52

------
https://chatgpt.com/codex/tasks/task_e_686c21a21d90832cbbc762bd514c0d64