### PR TITLE
Implementa health check e atualiza workflow

### DIFF
--- a/.github/workflows/render-deploy-and-check.yml
+++ b/.github/workflows/render-deploy-and-check.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Instalar dependências e verificar deploy
         run: |
           npm ci
-          node scripts/check-deploy.js
+          node scripts/check-deploy.js https://me-passa-a-cola.onrender.com/health

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ as integrações disponíveis.
 O repositório conta com um workflow do **GitHub Actions** que monitora se o
 deploy no Render está ativo. O arquivo
 `.github/workflows/render-deploy-and-check.yml` espera 45&nbsp;segundos antes de
-fazer uma requisição para `https://me-passa-a-cola.onrender.com/api-docs`. Se a
+fazer uma requisição para `https://me-passa-a-cola.onrender.com/health`. Se a
 resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
 produção.
 
@@ -640,6 +640,7 @@ Para testar manualmente, rode:
 node scripts/check-deploy.js [URL]
 ```
 
+Se nenhum URL for informado, ele verifica `https://me-passa-a-cola.onrender.com/health`.
 O script retorna código diferente de zero caso a URL não responda com `200`.
 
 ---

--- a/scripts/check-deploy.js
+++ b/scripts/check-deploy.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const url = process.argv[2] || 'https://me-passa-a-cola.onrender.com/api-docs';
+const url = process.argv[2] || 'https://me-passa-a-cola.onrender.com/health';
 
 async function main() {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,10 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.get('/api-docs.json', (req, res) => {
     res.json(swaggerDocument);
 });
+// Health check simples para validacao de deploy
+app.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+});
 // Documentação estática gerada com Doca
 app.use('/doca', express.static(path.join(__dirname, '..', 'docs')));
 


### PR DESCRIPTION
## Resumo
- cria endpoint `/health`
- atualiza script de checagem de deploy
- usa a nova rota de health check no workflow
- documenta nova rota no README

## Testes
- `npm test` *(falhou: express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686c2f003a98832c8e82d43414e7e0b8