### PR TITLE
Adiciona acionamento automático de workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,10 +333,14 @@ Headers:
   "content": {
   "novo.txt": "conteudo gerado"
   }
+  "githubToken": "ghp_xxx",      # opcional para disparar workflow
+  "githubOwner": "usuario",      # opcional
+  "githubRepo": "repositorio"    # opcional
 }
 ```
 
 O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
+Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
 ## 🚀 Endpoint para Notion + Git
 
@@ -358,7 +362,10 @@ Headers:
   "notion_token": "secret_xxx",
   "tema": "Matéria X",
   "subtitulo": "Aula 1",
-  "resumo": "Conteúdo em Markdown"
+  "resumo": "Conteúdo em Markdown",
+  "githubToken": "ghp_xxx",      # opcional para disparar workflow
+  "githubOwner": "usuario",      # opcional
+  "githubRepo": "repositorio"    # opcional
 }
 ```
 
@@ -381,21 +388,31 @@ API_TOKEN=seu_token PORT=3333 npm start
 ### 📁 Arquivo de configuração `.cola-config`
 
 Dentro de qualquer repositório usado pelas rotas de Git é possível criar um arquivo
-`.cola-config.yml` ou `.cola-config.json` com ajustes extras. Atualmente o campo
-`commitTemplate` permite definir o caminho de um template de commit utilizado quando
-`commitMessage` não é informado.
+`.cola-config.yml` ou `.cola-config.json` com ajustes extras. O campo
+`commitTemplate` define o template da mensagem de commit quando `commitMessage`
+não é informado. Também é possível indicar o workflow a ser disparado após cada
+commit através de `commitWorkflow` (nome ou `workflow_id`). Caso o workflow
+necessite autenticação, informe `githubToken`, `githubOwner` e `githubRepo`.
 
 Exemplo em YAML:
 
 ```yaml
 commitTemplate: .github/commit-template.md
+commitWorkflow: deploy.yml
+githubToken: ghp_xxx
+githubOwner: usuario
+githubRepo: repositorio
 ```
 
 Ou em JSON:
 
 ```json
 {
-  "commitTemplate": ".github/commit-template.md"
+  "commitTemplate": ".github/commit-template.md",
+  "commitWorkflow": "deploy.yml",
+  "githubToken": "ghp_xxx",
+  "githubOwner": "usuario",
+  "githubRepo": "repositorio"
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,12 @@ function loadTemplate(type, name = '') {
     }
 }
 
+function parseGitHubRepo(url) {
+    const match = url && url.match(/github\.com[:\/](.+?)\/(.+?)(?:\.git)?$/);
+    if (!match) return { owner: '', repo: '' };
+    return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
+}
+
 // Endpoint principal
 app.post("/create-notion-content", async (req, res) => {
     try {
@@ -692,6 +698,21 @@ app.patch('/git-file', async (req, res) => {
 
         await commitAndPush(repoPath, finalMsg, [fullPath], branch);
 
+        const workflowId = config.commitWorkflow || config.workflow || config.workflow_id;
+        if (workflowId) {
+            const repoInfo = parseGitHubRepo(repoUrl);
+            const owner = req.body.githubOwner || config.githubOwner || repoInfo.owner;
+            const repo = req.body.githubRepo || config.githubRepo || repoInfo.repo;
+            const token = req.body.githubToken || config.githubToken;
+            if (token && owner && repo) {
+                try {
+                    await dispatchWorkflow({ token, owner, repo, workflow_id: workflowId, ref: branch });
+                } catch (wErr) {
+                    console.warn('Falha ao acionar workflow:', wErr.message);
+                }
+            }
+        }
+
         res.json({ ok: true });
     } catch (err) {
         console.error(err);
@@ -734,6 +755,21 @@ app.post('/git-commit', async (req, res) => {
 
         const pathsToAdd = files.map(f => path.join(repoPath, f));
         await commitAndPush(repoPath, finalMsg, pathsToAdd, branch);
+
+        const workflowId = config.commitWorkflow || config.workflow || config.workflow_id;
+        if (workflowId) {
+            const repoInfo = parseGitHubRepo(repoUrl);
+            const owner = req.body.githubOwner || config.githubOwner || repoInfo.owner;
+            const repo = req.body.githubRepo || config.githubRepo || repoInfo.repo;
+            const token = req.body.githubToken || config.githubToken;
+            if (token && owner && repo) {
+                try {
+                    await dispatchWorkflow({ token, owner, repo, workflow_id: workflowId, ref: branch });
+                } catch (wErr) {
+                    console.warn('Falha ao acionar workflow:', wErr.message);
+                }
+            }
+        }
 
         res.json({ ok: true });
     } catch (err) {
@@ -829,6 +865,21 @@ app.post('/create-notion-content-git', async (req, res) => {
         fs.writeFileSync(fullPath, resumo);
 
         await commitAndPush(repoPath, finalMsg, [fullPath], branch);
+
+        const workflowId = config.commitWorkflow || config.workflow || config.workflow_id;
+        if (workflowId) {
+            const repoInfo = parseGitHubRepo(repoUrl);
+            const owner = req.body.githubOwner || config.githubOwner || repoInfo.owner;
+            const repo = req.body.githubRepo || config.githubRepo || repoInfo.repo;
+            const token = req.body.githubToken || config.githubToken;
+            if (token && owner && repo) {
+                try {
+                    await dispatchWorkflow({ token, owner, repo, workflow_id: workflowId, ref: branch });
+                } catch (wErr) {
+                    console.warn('Falha ao acionar workflow:', wErr.message);
+                }
+            }
+        }
 
         res.json({
             ok: true,


### PR DESCRIPTION
## Resumo
- dispara workflows após os commits
- registra função para extrair owner/repo do URL
- documenta novo campo `commitWorkflow` e credenciais

## Testes
- `npm test` *(falha: express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ce1d7d0832ca15661aaa7b7c289