### PR TITLE
Implementação de issueRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,13 @@ commitWorkflow: deploy.yml
 githubToken: ghp_xxx
 githubOwner: usuario
 githubRepo: repositorio
+defaultIssueProject: proj1
+issueRules:
+  - if:
+      labels: ['bug']
+    set:
+      milestone: 'Sprint 1'
+      column: 'Bugs'
 ```
 
 Ou em JSON:
@@ -415,6 +422,8 @@ Ou em JSON:
   "githubRepo": "repositorio"
 }
 ```
+
+O campo `issueRules` permite automatizar passos após criar ou atualizar uma issue. Veja um exemplo de regra que define milestone e coluna quando a label `bug` estiver presente.
 
 Crie também o arquivo citado no campo `commitTemplate`. Esse documento será lido
 como base para a mensagem de commit. Caso não exista configuração, o caminho

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,16 @@ defaultIssueColumn: col1
 As mesmas opções podem ser definidas em JSON.
 
 Os campos `defaultIssueMilestone`, `defaultIssueProject` e `defaultIssueColumn` definem valores padrão para a rota `/github-issues` quando `milestone` ou `column_id` não são enviados na requisição.
+
+Também é possível definir `issueRules` para aplicar ações automáticas em issues recém criadas ou atualizadas. Exemplo:
+
+```yaml
+issueRules:
+  - if:
+      labels: ['bug']
+    set:
+      milestone: 'Sprint 1'
+      column: 'Bugs'
+```
+
+Se a issue possuir a label **bug**, ela será movida para a coluna indicada e terá a milestone atribuída automaticamente.

--- a/src/utils/issue-rules.js
+++ b/src/utils/issue-rules.js
@@ -1,0 +1,80 @@
+const {
+    updateIssue,
+    listMilestones,
+    listProjects,
+    listProjectColumns,
+    addIssueToProject
+} = require('./github');
+
+/**
+ * Aplica regras configuradas para issues.
+ * @param {object} issue Objeto retornado pela API do GitHub
+ * @param {object} opts Parâmetros com token, owner, repo e issueRules
+ */
+async function applyIssueRules(issue, opts = {}) {
+    const { token, owner, repo, issueRules = [], defaultIssueProject } = opts;
+    if (!token || !owner || !repo || !Array.isArray(issueRules)) return;
+
+    for (const rule of issueRules) {
+        const cond = rule.if || {};
+        const actions = rule.set || {};
+        let match = true;
+        if (cond.labels && cond.labels.length) {
+            const labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+            for (const l of cond.labels) {
+                if (!labels.includes(l)) {
+                    match = false;
+                    break;
+                }
+            }
+        }
+        if (!match) continue;
+
+        let milestoneNumber = actions.milestone;
+        if (milestoneNumber && isNaN(Number(milestoneNumber))) {
+            try {
+                const ms = await listMilestones({ token, owner, repo, state: 'all' });
+                const found = ms.find(m => m.title === milestoneNumber);
+                if (found) milestoneNumber = found.number;
+            } catch (err) {
+                console.warn('Falha ao buscar milestone:', err.message);
+            }
+        }
+        if (milestoneNumber !== undefined) {
+            try {
+                await updateIssue({ token, owner, repo, issue_number: issue.number, milestone: milestoneNumber });
+            } catch (err) {
+                console.warn('Falha ao atualizar issue:', err.message);
+            }
+        }
+
+        if (actions.column) {
+            let columnId = actions.column;
+            if (isNaN(Number(columnId))) {
+                try {
+                    let projectId = defaultIssueProject;
+                    if (!projectId) {
+                        const projects = await listProjects({ token, owner, repo });
+                        if (projects.length > 0) projectId = projects[0].id;
+                    }
+                    if (projectId) {
+                        const cols = await listProjectColumns({ token, project_id: projectId });
+                        const found = cols.find(c => c.name === columnId);
+                        if (found) columnId = found.id;
+                    }
+                } catch (err) {
+                    console.warn('Falha ao obter coluna do projeto:', err.message);
+                }
+            }
+            if (columnId) {
+                try {
+                    await addIssueToProject({ token, column_id: columnId, issue_id: issue.node_id });
+                } catch (err) {
+                    console.warn('Falha ao mover issue para coluna:', err.message);
+                }
+            }
+        }
+    }
+}
+
+module.exports = { applyIssueRules };


### PR DESCRIPTION
## Resumo
- adicionar módulo `issue-rules` com aplicação automática de regras de issues
- utilizar `applyIssueRules` nas rotas POST/PATCH de `/github-issues`
- documentar `issueRules` no README e em `docs/README.md`
- adicionar testes de regras de issue

## Testes
- `npm test` *(falhou: express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686c46bd234c832c81725503aebaa7ca