### PR TITLE
Atualizar API para evitar path params

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,12 +513,13 @@ O campo `milestone` aceita o número ou o título da milestone.
 ### Atualizar Issue
 
 ```http
-PATCH /github-issues/{numero}
+PATCH /github-issues
 
 {
   "token": "ghp_xxx",
   "owner": "usuario",
   "repo": "repositorio",
+  "number": 123,
   "title": "Novo título",
   "state": "open",
   "milestone": 1
@@ -528,12 +529,13 @@ PATCH /github-issues/{numero}
 ### Fechar Issue
 
 ```http
-DELETE /github-issues/{numero}
+DELETE /github-issues
 
 {
   "token": "ghp_xxx",
   "owner": "usuario",
-  "repo": "repositorio"
+  "repo": "repositorio",
+  "number": 123
 }
 ```
 
@@ -579,12 +581,13 @@ GET /github-milestones?token=ghp_xxx&owner=usuario&repo=repositorio&state=open
 ### Atualizar Milestone
 
 ```http
-PATCH /github-milestones/{numero}
+PATCH /github-milestones
 
 {
   "token": "ghp_xxx",
   "owner": "usuario",
   "repo": "repositorio",
+  "number": 1,
   "title": "Sprint 1 - Ajuste"
 }
 ```
@@ -605,10 +608,11 @@ POST /github-projects
 ### Criar Column no Projeto (GraphQL)
 
 ```http
-POST /github-projects/{project_id}/columns
+POST /github-projects/columns
 
 {
   "token": "ghp_xxx",
+  "project_id": "proj1",
   "name": "To Do"
 }
 ```
@@ -616,10 +620,11 @@ POST /github-projects/{project_id}/columns
 ### Adicionar Issue ao Projeto (use `node_id` da issue)
 
 ```http
-POST /github-projects/columns/{column_id}/cards
+POST /github-projects/columns/cards
 
 {
   "token": "ghp_xxx",
+  "column_id": "col1",
   "issue_id": "abc123"
 }
 ```
@@ -633,7 +638,7 @@ GET /github-projects?token=ghp_xxx&owner=usuario&repo=repositorio
 ### Listar Colunas do Projeto
 
 ```http
-GET /github-projects/{project_id}/columns?token=ghp_xxx
+GET /github-projects/columns?token=ghp_xxx&project_id=proj1
 ```
 
 ### Criar Pull Request
@@ -677,23 +682,25 @@ Use o campo `type` para indicar qual modelo de PR será utilizado (`feature`, `f
 ### Atualizar/Fechar Pull Request
 
 ```http
-PATCH /github-pulls/{numero}
+PATCH /github-pulls
 
 {
   "token": "ghp_xxx",
   "owner": "usuario",
   "repo": "repositorio",
+  "number": 10,
   "title": "Novo título"
 }
 ```
 
 ```http
-DELETE /github-pulls/{numero}
+DELETE /github-pulls
 
 {
   "token": "ghp_xxx",
   "owner": "usuario",
-  "repo": "repositorio"
+  "repo": "repositorio",
+  "number": 10
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,11 +47,11 @@ do arquivo `.cola-config` são utilizados, quando presentes.
 
 Lista issues do repositório
 
-## PATCH /github-issues/{number}
+## PATCH /github-issues
 
 Atualiza uma issue existente
 
-## DELETE /github-issues/{number}
+## DELETE /github-issues
 
 Fecha uma issue
 
@@ -75,7 +75,7 @@ Cria uma milestone
 
 Lista milestones do repositório
 
-## PATCH /github-milestones/{number}
+## PATCH /github-milestones
 
 Atualiza uma milestone
 
@@ -87,18 +87,18 @@ Cria um projeto via GraphQL
 
 Lista projetos do repositório
 
-## POST /github-projects/{project_id}/columns
+## POST /github-projects/columns
 
 Cria coluna em um projeto via GraphQL
 
 > **Nota**: se a resposta do GitHub contiver `errors`, o serviço retorna
 > a mensagem de erro fornecida pela API.
 
-## GET /github-projects/{project_id}/columns
+## GET /github-projects/columns
 
 Lista colunas de um projeto
 
-## POST /github-projects/columns/{column_id}/cards
+## POST /github-projects/columns/cards
 
 Adiciona issue ao projeto via GraphQL (use o `node_id` da issue)
 
@@ -110,11 +110,11 @@ Cria um pull request
 
 Cria e mescla automaticamente um pull request a partir de um template definido em `.cola-config`. Envie `autoClose: true` para fechar o PR após o merge.
 
-## PATCH /github-pulls/{number}
+## PATCH /github-pulls
 
 Atualiza um pull request
 
-## DELETE /github-pulls/{number}
+## DELETE /github-pulls
 
 Fecha um pull request
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -191,7 +191,7 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/github-issues/{number}": {
+    "/github-issues": {
       "patch": {
         "operationId": "atualizarIssue",
         "description": "Atualiza uma issue existente",
@@ -268,7 +268,7 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/github-milestones/{number}": {
+    "/github-milestones": {
       "patch": {
         "operationId": "atualizarMilestone",
         "description": "Atualiza uma milestone",
@@ -300,7 +300,7 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/github-projects/{project_id}/columns": {
+    "/github-projects/columns": {
       "post": {
         "operationId": "criarColunaProjeto",
         "description": "Cria coluna em um projeto via GraphQL",
@@ -315,12 +315,12 @@
         "description": "Lista colunas de um projeto",
         "parameters": [
           { "name": "token", "in": "query", "required": true, "schema": { "type": "string" } },
-          { "name": "project_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          { "name": "project_id", "in": "query", "required": true, "schema": { "type": "string" } }
         ],
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/github-projects/columns/{column_id}/cards": {
+    "/github-projects/columns/cards": {
       "post": {
         "operationId": "adicionarIssueProjeto",
         "description": "Adiciona issue ao projeto via GraphQL",
@@ -340,9 +340,7 @@
           "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GithubPullCreate" } } }
         },
         "responses": { "200": { "description": "Sucesso" } }
-      }
-    },
-    "/github-pulls/{number}": {
+      },
       "patch": {
         "operationId": "atualizarPullRequest",
         "description": "Atualiza um pull request",
@@ -646,6 +644,7 @@
             "token": { "type": "string" },
             "owner": { "type": "string" },
             "repo": { "type": "string" },
+            "number": { "type": "integer" },
             "title": { "type": "string" },
             "body": { "type": "string" },
             "state": { "type": "string" },
@@ -668,16 +667,17 @@
               ]
             }
           },
-          "required": ["token", "owner", "repo"]
+          "required": ["token", "owner", "repo", "number"]
         },
         "GithubIssueDelete": {
           "type": "object",
           "properties": {
             "token": { "type": "string" },
             "owner": { "type": "string" },
-            "repo": { "type": "string" }
+            "repo": { "type": "string" },
+            "number": { "type": "integer" }
           },
-          "required": ["token", "owner", "repo"]
+          "required": ["token", "owner", "repo", "number"]
         },
         "GithubWorkflowDispatch": {
           "type": "object",
@@ -722,12 +722,13 @@
             "token": { "type": "string" },
             "owner": { "type": "string" },
             "repo": { "type": "string" },
+            "number": { "type": "integer" },
             "title": { "type": "string" },
             "state": { "type": "string" },
             "description": { "type": "string" },
             "due_on": { "type": "string" }
           },
-          "required": ["token", "owner", "repo"]
+          "required": ["token", "owner", "repo", "number"]
         },
         "GithubProjectCreate": {
           "type": "object",
@@ -777,20 +778,22 @@
             "token": { "type": "string" },
             "owner": { "type": "string" },
             "repo": { "type": "string" },
+            "number": { "type": "integer" },
             "title": { "type": "string" },
             "body": { "type": "string" },
             "state": { "type": "string" }
           },
-          "required": ["token", "owner", "repo"]
+          "required": ["token", "owner", "repo", "number"]
         },
         "GithubPullDelete": {
           "type": "object",
           "properties": {
             "token": { "type": "string" },
             "owner": { "type": "string" },
-            "repo": { "type": "string" }
+            "repo": { "type": "string" },
+            "number": { "type": "integer" }
           },
-          "required": ["token", "owner", "repo"]
+          "required": ["token", "owner", "repo", "number"]
         },
         "LinearIssueProjectUpdate": {
           "type": "object",

--- a/src/index.js
+++ b/src/index.js
@@ -979,11 +979,10 @@ app.post('/github-issues', async (req, res) => {
     }
 });
 
-app.patch('/github-issues/:number', async (req, res) => {
-    const { token, owner, repo, milestone, repoUrl, credentials } = req.body;
-    const { number } = req.params;
-    if (!token || !owner || !repo) {
-        return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
+app.patch('/github-issues', async (req, res) => {
+    const { token, owner, repo, number, milestone, repoUrl, credentials } = req.body;
+    if (!token || !owner || !repo || !number) {
+        return res.status(400).json({ error: 'token, owner, repo e number são obrigatórios' });
     }
     try {
         let config = {};
@@ -1014,11 +1013,10 @@ app.patch('/github-issues/:number', async (req, res) => {
     }
 });
 
-app.delete('/github-issues/:number', async (req, res) => {
-    const { token, owner, repo } = req.body;
-    const { number } = req.params;
-    if (!token || !owner || !repo) {
-        return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
+app.delete('/github-issues', async (req, res) => {
+    const { token, owner, repo, number } = req.body;
+    if (!token || !owner || !repo || !number) {
+        return res.status(400).json({ error: 'token, owner, repo e number são obrigatórios' });
     }
     try {
         const issue = await closeIssue({ token, owner, repo, issue_number: number });
@@ -1085,11 +1083,10 @@ app.get('/github-milestones', async (req, res) => {
     }
 });
 
-app.patch('/github-milestones/:number', async (req, res) => {
-    const { token, owner, repo } = req.body;
-    const { number } = req.params;
-    if (!token || !owner || !repo) {
-        return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
+app.patch('/github-milestones', async (req, res) => {
+    const { token, owner, repo, number } = req.body;
+    if (!token || !owner || !repo || !number) {
+        return res.status(400).json({ error: 'token, owner, repo e number são obrigatórios' });
     }
     try {
         const milestone = await updateMilestone({ token, owner, repo, milestone_number: number, ...req.body });
@@ -1114,9 +1111,8 @@ app.post('/github-projects', async (req, res) => {
     }
 });
 
-app.post('/github-projects/:project_id/columns', async (req, res) => {
-    const { token, name } = req.body;
-    const { project_id } = req.params;
+app.post('/github-projects/columns', async (req, res) => {
+    const { token, project_id, name } = req.body;
     if (!token || !project_id || !name) {
         return res.status(400).json({ error: 'token, project_id e name são obrigatórios' });
     }
@@ -1129,9 +1125,8 @@ app.post('/github-projects/:project_id/columns', async (req, res) => {
     }
 });
 
-app.post('/github-projects/columns/:column_id/cards', async (req, res) => {
-    const { token, issue_id } = req.body;
-    const { column_id } = req.params;
+app.post('/github-projects/columns/cards', async (req, res) => {
+    const { token, column_id, issue_id } = req.body;
     if (!token || !column_id || !issue_id) {
         return res.status(400).json({ error: 'token, column_id e issue_id são obrigatórios' });
     }
@@ -1158,9 +1153,8 @@ app.get('/github-projects', async (req, res) => {
     }
 });
 
-app.get('/github-projects/:project_id/columns', async (req, res) => {
-    const { token } = req.query;
-    const { project_id } = req.params;
+app.get('/github-projects/columns', async (req, res) => {
+    const { token, project_id } = req.query;
     if (!token || !project_id) {
         return res.status(400).json({ error: 'token e project_id são obrigatórios' });
     }
@@ -1253,11 +1247,10 @@ app.post('/github-pulls/auto', async (req, res) => {
     }
 });
 
-app.patch('/github-pulls/:number', async (req, res) => {
-    const { token, owner, repo } = req.body;
-    const { number } = req.params;
-    if (!token || !owner || !repo) {
-        return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
+app.patch('/github-pulls', async (req, res) => {
+    const { token, owner, repo, number } = req.body;
+    if (!token || !owner || !repo || !number) {
+        return res.status(400).json({ error: 'token, owner, repo e number são obrigatórios' });
     }
     try {
         const pull = await updatePullRequest({ token, owner, repo, pull_number: number, ...req.body });
@@ -1268,11 +1261,10 @@ app.patch('/github-pulls/:number', async (req, res) => {
     }
 });
 
-app.delete('/github-pulls/:number', async (req, res) => {
-    const { token, owner, repo } = req.body;
-    const { number } = req.params;
-    if (!token || !owner || !repo) {
-        return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
+app.delete('/github-pulls', async (req, res) => {
+    const { token, owner, repo, number } = req.body;
+    if (!token || !owner || !repo || !number) {
+        return res.status(400).json({ error: 'token, owner, repo e number são obrigatórios' });
     }
     try {
         const pull = await closePullRequest({ token, owner, repo, pull_number: number });

--- a/tests/run.js
+++ b/tests/run.js
@@ -39,7 +39,7 @@ async function testBasicEndpoints() {
   assert(spec.paths['/create-notion-content']);
   assert(spec.paths['/github-issues']);
   assert(spec.paths['/github-projects']);
-  assert(spec.paths['/github-projects/columns/{column_id}/cards']);
+  assert(spec.paths['/github-projects/columns/cards']);
   server.close();
 }
 
@@ -139,20 +139,20 @@ async function testGithubProjectRoutes() {
   assert(projectData.project);
   const projectId = projectData.project.id;
 
-  const columnRes = await fetch(`http://localhost:${port}/github-projects/${projectId}/columns`, {
+  const columnRes = await fetch(`http://localhost:${port}/github-projects/columns`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token: 't', name: 'Col' })
+    body: JSON.stringify({ token: 't', project_id: projectId, name: 'Col' })
   });
   assert.strictEqual(columnRes.status, 200);
   const columnData = await columnRes.json();
   assert(columnData.column);
   const columnId = columnData.column.id;
 
-  const cardRes = await fetch(`http://localhost:${port}/github-projects/columns/${columnId}/cards`, {
+  const cardRes = await fetch(`http://localhost:${port}/github-projects/columns/cards`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token: 't', issue_id: 'issue1' })
+    body: JSON.stringify({ token: 't', column_id: columnId, issue_id: 'issue1' })
   });
   assert.strictEqual(cardRes.status, 200);
   const cardData = await cardRes.json();


### PR DESCRIPTION
## Resumo
- mudar endpoints que usavam parâmetros de caminho para receber valores no corpo ou query
- documentar novas rotas no README e em `docs/API.md`
- atualizar especificação OpenAPI
- ajustar testes para as novas rotas

## Testes
- `npm test` *(falha: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686ca21b85bc832c8e8dd4397d68f044