### PR TITLE
Adiciona endpoint de PR automático

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -110,6 +110,22 @@ Cria um pull request
 
 Cria e mescla automaticamente um pull request a partir de um template definido em `.cola-config`. Envie `autoClose: true` para fechar o PR após o merge.
 
+```http
+POST /github-pulls/auto
+
+{
+  "token": "ghp_xxx",
+  "owner": "usuario",
+  "repo": "repositorio",
+  "head": "feature-branch",
+  "base": "main",
+  "repoUrl": "https://github.com/usuario/repositorio.git",
+  "credentials": "usuario:token",
+  "type": "feature",
+  "autoClose": true
+}
+```
+
 ## PATCH /github-pulls
 
 Atualiza um pull request

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Os campos `defaultIssueMilestone`, `defaultIssueProject` e `defaultIssueColumn` 
 
 Use `pullRequestTemplates` para apontar arquivos de template por tipo de PR. O título será a primeira linha do arquivo e o restante compõe o corpo do pull request.
 
+Esses templates também são utilizados pela rota `/github-pulls/auto`, que cria e mescla PRs automaticamente. Envie `autoClose: true` para fechar o PR após o merge.
+
 Também é possível definir `issueRules` para aplicar ações automáticas em issues recém criadas ou atualizadas. Exemplo:
 
 ```yaml

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -368,6 +368,17 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/github-pulls/auto": {
+      "post": {
+        "operationId": "criarPrAutomatico",
+        "description": "Cria e mescla automaticamente um pull request usando template definido em `.cola-config`",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GithubPullAuto" } } }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/linear-issues/project": {
       "post": {
         "operationId": "atualizarProjetoIssueLinear",
@@ -794,6 +805,21 @@
             "number": { "type": "integer" }
           },
           "required": ["token", "owner", "repo", "number"]
+        },
+        "GithubPullAuto": {
+          "type": "object",
+          "properties": {
+            "token": { "type": "string" },
+            "owner": { "type": "string" },
+            "repo": { "type": "string" },
+            "head": { "type": "string" },
+            "base": { "type": "string" },
+            "repoUrl": { "type": "string" },
+            "credentials": { "type": "string" },
+            "type": { "type": "string" },
+            "autoClose": { "type": "boolean" }
+          },
+          "required": ["token", "owner", "repo", "head", "repoUrl"]
         },
         "LinearIssueProjectUpdate": {
           "type": "object",

--- a/gpt/prompt_auxiliar_projetos.md
+++ b/gpt/prompt_auxiliar_projetos.md
@@ -56,9 +56,9 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
 - **Acionar e Monitorar Pipelines (Workflows do GitHub):** Dispara workflows e consulta seus status.
   - *Ferramentas:* `dispararWorkflow`, `statusWorkflow`.
   - *Parâmetros a inferir:* `token` (GitHub), `owner`, `repo`, `workflow_id` (ID do workflow), `ref` (branch), `inputs` (parâmetros para o workflow), `run_id` (ID da execução do workflow).
-- **Gerenciar Pull Requests:** Cria, atualiza ou fecha PRs para revisão de código.
-  - *Ferramentas:* `criarPullRequest`, `atualizarPullRequest`, `fecharPullRequest`.
-  - *Parâmetros a inferir:* `token`, `owner`, `repo`, `title`, `head`, `base`, `number`, `body`.
+- **Gerenciar Pull Requests:** Cria, mescla automaticamente, atualiza ou fecha PRs para revisão de código.
+  - *Ferramentas:* `criarPullRequest`, `criarPrAutomatico`, `atualizarPullRequest`, `fecharPullRequest`.
+  - *Parâmetros a inferir:* `token`, `owner`, `repo`, `title`, `head`, `base`, `number`, `body`, `repoUrl`, `credentials`, `type`, `autoClose`.
 
 ### 5. Busca de Conteúdo Existente
 
@@ -85,7 +85,7 @@ Ao interagir com o usuário, o modelo pode guiar a conversa ou sugerir ações b
 4.  **Entrega Contínua:**
       -   "Precisamos registrar as mudanças? Posso fazer um commit no Git. Quer que eu verifique o status de algum workflow?" (usar `gitCommit`, `statusWorkflow`).
 5.  **Revisão de Código:**
-      -   "Vou abrir um pull request para revisão ou atualizá-lo conforme necessário." (usar `criarPullRequest` ou `atualizarPullRequest`).
+      -   "Vou abrir um pull request para revisão ou mesclá-lo automaticamente se preferir." (usar `criarPullRequest`, `criarPrAutomatico` ou `atualizarPullRequest`).
 6.  **Registro Centralizado:**
       -   "Todas as decisões e atas de reunião podem ser centralizadas no Notion." (usar `enviarResumos`).
 
@@ -111,5 +111,5 @@ Agora, se o usuário disser:
 *   "Envie este PDF para minha base do Notion."
     *   O modelo deve solicitar o arquivo em base64 e usar `enviarPDF`.
 *   "Abra um pull request com a nova feature."
-    *   O modelo deve usar `criarPullRequest`, inferindo `title`, `head` e `base`.
+    *   O modelo deve usar `criarPullRequest` ou `criarPrAutomatico`, inferindo `title`, `head`, `base` e demais parâmetros necessários.
 


### PR DESCRIPTION
## Resumo
- insere rota `/github-pulls/auto` em `actions.json`
- registra schema `GithubPullAuto`
- documenta exemplo do endpoint em `docs/API.md`
- menciona uso automático dos templates em `docs/README.md`
- atualiza `prompt_auxiliar_projetos.md` com nova ferramenta

## Testes
- `npm test` *(falhou: express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686d1a355f90832cbeee075b118e5770