### PR TITLE
Add Git file routes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,14 @@ Headers:
 O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
 Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
+## \ud83d\udcc2 Endpoints para arquivos do Git
+
+Permitem listar diret\u00f3rios e ler ou atualizar arquivos individuais.
+
+- `GET /git-files` lista arquivos de um caminho (par\u00e2metros: `repoUrl`, `credentials`, `path`).
+- `GET /git-file` obt\u00e9m o conte\u00fado de um arquivo (par\u00e2metros: `repoUrl`, `credentials`, `file`).
+- `PATCH /git-file` cria ou atualiza o arquivo e executa um commit.
+
 ## 🚀 Endpoint para Notion + Git
 
 Cria o conteúdo no Notion e salva o mesmo texto em um repositório Git.

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,20 @@ Atualiza títulos e tags das subpáginas de um tema no Notion.
 
 Remove tags não utilizadas do banco de dados.
 
+
+## GET /git-files
+
+Lista os arquivos de um diretório do repositório.
+
+## GET /git-file
+
+
+Retorna o conteúdo de um arquivo do repositório.
+
+## PATCH /git-file
+
+Atualiza ou cria um arquivo e realiza commit.
+
 ## POST /git-commit
 
 Realiza commit em repositório privado usando token

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -107,6 +107,48 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
+    "/git-files": {
+      "get": {
+        "operationId": "listarArquivosGit",
+        "description": "Lista os arquivos de um diret\u00f3rio do reposit\u00f3rio",
+        "parameters": [
+          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } },
+          { "name": "repoUrl", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "credentials", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "path", "in": "query", "required": false, "schema": { "type": "string", "default": "." } }
+        ],
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
+    "/git-file": {
+      "get": {
+        "operationId": "obterArquivoGit",
+        "description": "Retorna o conte\u00fado de um arquivo",
+        "parameters": [
+          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } },
+          { "name": "repoUrl", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "credentials", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "file", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Sucesso" } }
+      },
+      "patch": {
+        "operationId": "atualizarArquivoGit",
+        "description": "Atualiza ou cria um arquivo e realiza commit",
+        "parameters": [
+          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/GitFileUpdate" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Sucesso" } }
+      }
+    },
     "/git-commit": {
       "post": {
         "operationId": "gitCommit",
@@ -537,6 +579,21 @@
         "required": ["repoUrl", "credentials"]
   },
 
+      "GitFileUpdate": {
+        "type": "object",
+        "properties": {
+          "repoUrl": { "type": "string" },
+          "credentials": { "type": "string" },
+          "filePath": { "type": "string" },
+          "content": { "type": "string" },
+          "commitMessage": { "type": "string" },
+          "branch": { "type": "string" },
+          "githubToken": { "type": "string" },
+          "githubOwner": { "type": "string" },
+          "githubRepo": { "type": "string" }
+        },
+        "required": ["repoUrl", "credentials", "filePath", "content"]
+      },
       "NotionContentGit": {
         "type": "object",
         "properties": {

--- a/gpt/prompt_auxiliar_projetos.md
+++ b/gpt/prompt_auxiliar_projetos.md
@@ -34,6 +34,12 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
   - *Parâmetros a inferir para `gitCommit`:* `repoUrl`, `credentials`, `message`, `files` (caminhos dos arquivos), `content` (conteúdo dos arquivos), `branch`.
   - *Parâmetros a inferir para `criarNotionGit`:* `repoUrl`, `credentials`, `commitMessage`, `filePath`, `notion_token`, `resumo` (conteúdo do Notion).
 
+- **Consultar ou Editar Arquivos Existentes:** Liste diret\u00f3rios ou leia/atualize arquivos no reposit\u00f3rio.
+  - *Ferramentas:* `listarArquivosGit` (`git-files`), `obterArquivoGit` / `atualizarArquivoGit` (`git-file`).
+  - *Par\u00e2metros a inferir para `listarArquivosGit`:* `repoUrl`, `credentials`, `path`.
+  - *Par\u00e2metros a inferir para `obterArquivoGit`:* `repoUrl`, `credentials`, `file`.
+  - *Par\u00e2metros a inferir para `atualizarArquivoGit`:* `repoUrl`, `credentials`, `filePath`, `content`, `commitMessage`, `branch`.
+
 ### 2. Planejamento e Priorização (Gerenciamento de Issues)
 
 - **Gerenciar Backlog e Tarefas no GitHub:** Cria, lista, atualiza ou fecha issues. Ideal para quebrar features em tarefas, definir prioridades e acompanhar o progresso.


### PR DESCRIPTION
## Summary
- document new `/git-files` and `/git-file` routes
- expose routes in OpenAPI actions file
- mention git file endpoints in README
- update auxiliary prompt with details about listing and editing git files
- fix minor wording in route description

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686d281f847c832c93410866e29456dd