### PR TITLE
Fix duplicate heading in prompt

### DIFF
--- a/gpt/prompt.md
+++ b/gpt/prompt.md
@@ -57,8 +57,6 @@
 - 🗂️ Flashcards: sempre com base nos tópicos estruturados (exportáveis ao Notion).
 - 🛄 Exportar para Notion ou Markdown.
 
-## 🖋️ Formatação dos Resumos Detalhados (Markdown)
-
 ## 🖋️ Formatação dos Resumos Detalhados e Artigos (Markdown)
 
 - Sempre começar com `#` Título do tema


### PR DESCRIPTION
## Summary
- remove redundant heading around line 60
- ensure final newline in `gpt/prompt.md`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686d2e791e70832ca42d31087623f4d5