### PR TITLE
Move API token to query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,7 @@ A API disponibiliza a rota `POST /git-commit` para realizar commits em repositó
 ### Requisição
 
 ```http
-POST /git-commit
-Headers:
-  x-api-token: <seu_token>
+POST /git-commit?x-api-token=<seu_token>
 
 {
   "repoUrl": "https://github.com/usuario/repositorio.git",
@@ -339,7 +337,7 @@ Headers:
 }
 ```
 
-O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
+O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo parâmetro de query `x-api-token`.
 Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
 ## \ud83d\udcc2 Endpoints para arquivos do Git
@@ -357,9 +355,7 @@ Cria o conteúdo no Notion e salva o mesmo texto em um repositório Git.
 ### Requisição
 
 ```http
-POST /create-notion-content-git
-Headers:
-  x-api-token: <seu_token>
+POST /create-notion-content-git?x-api-token=<seu_token>
 
 {
   "repoUrl": "https://github.com/usuario/repositorio.git",

--- a/docs/index.md
+++ b/docs/index.md
@@ -320,9 +320,7 @@ A API disponibiliza a rota `POST /git-commit` para realizar commits em repositó
 ### Requisição
 
 ```http
-POST /git-commit
-Headers:
-  x-api-token: <seu_token>
+POST /git-commit?x-api-token=<seu_token>
 
 {
   "repoUrl": "https://github.com/usuario/repositorio.git",
@@ -339,7 +337,7 @@ Headers:
 }
 ```
 
-O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo cabeçalho `x-api-token`.
+O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo parâmetro de query `x-api-token`.
 Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
 ## \ud83d\udcc2 Endpoints para arquivos do Git
@@ -357,9 +355,7 @@ Cria o conteúdo no Notion e salva o mesmo texto em um repositório Git.
 ### Requisição
 
 ```http
-POST /create-notion-content-git
-Headers:
-  x-api-token: <seu_token>
+POST /create-notion-content-git?x-api-token=<seu_token>
 
 {
   "repoUrl": "https://github.com/usuario/repositorio.git",

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -112,7 +112,7 @@
         "operationId": "listarArquivosGit",
         "description": "Lista os arquivos de um diret\u00f3rio do reposit\u00f3rio",
         "parameters": [
-          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } },
+          { "name": "x-api-token", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "repoUrl", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "credentials", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "path", "in": "query", "required": false, "schema": { "type": "string", "default": "." } }
@@ -125,7 +125,7 @@
         "operationId": "obterArquivoGit",
         "description": "Retorna o conte\u00fado de um arquivo",
         "parameters": [
-          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } },
+          { "name": "x-api-token", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "repoUrl", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "credentials", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "file", "in": "query", "required": true, "schema": { "type": "string" } }
@@ -136,7 +136,7 @@
         "operationId": "atualizarArquivoGit",
         "description": "Atualiza ou cria um arquivo e realiza commit",
         "parameters": [
-          { "name": "x-api-token", "in": "header", "required": true, "schema": { "type": "string" } }
+          { "name": "x-api-token", "in": "query", "required": true, "schema": { "type": "string" } }
         ],
         "requestBody": {
           "required": true,
@@ -156,7 +156,7 @@
         "parameters": [
           {
             "name": "x-api-token",
-            "in": "header",
+            "in": "query",
             "required": true,
             "schema": { "type": "string" }
           }
@@ -179,7 +179,7 @@
         "parameters": [
           {
             "name": "x-api-token",
-            "in": "header",
+            "in": "query",
             "required": true,
             "schema": { "type": "string" }
           }

--- a/src/index.js
+++ b/src/index.js
@@ -637,7 +637,8 @@ app.post('/limpar-tags-orfas', async (req, res) => {
 });
 
 app.get('/git-files', async (req, res) => {
-    if (req.header('x-api-token') !== API_TOKEN) {
+    const token = req.query['x-api-token'] || req.header('x-api-token');
+    if (token !== API_TOKEN) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
@@ -658,7 +659,8 @@ app.get('/git-files', async (req, res) => {
 });
 
 app.get('/git-file', async (req, res) => {
-    if (req.header('x-api-token') !== API_TOKEN) {
+    const token = req.query['x-api-token'] || req.header('x-api-token');
+    if (token !== API_TOKEN) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
@@ -679,7 +681,8 @@ app.get('/git-file', async (req, res) => {
 });
 
 app.patch('/git-file', async (req, res) => {
-    if (req.header('x-api-token') !== API_TOKEN) {
+    const token = req.query['x-api-token'] || req.header('x-api-token');
+    if (token !== API_TOKEN) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
@@ -733,7 +736,8 @@ app.patch('/git-file', async (req, res) => {
 });
 
 app.post('/git-commit', async (req, res) => {
-    if (req.header('x-api-token') !== API_TOKEN) {
+    const token = req.query['x-api-token'] || req.header('x-api-token');
+    if (token !== API_TOKEN) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
@@ -791,7 +795,8 @@ app.post('/git-commit', async (req, res) => {
 });
 
 app.post('/create-notion-content-git', async (req, res) => {
-    if (req.header('x-api-token') !== API_TOKEN) {
+    const token = req.query['x-api-token'] || req.header('x-api-token');
+    if (token !== API_TOKEN) {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 

--- a/tests/run.js
+++ b/tests/run.js
@@ -77,9 +77,7 @@ async function testGitFileRoute() {
   const server = startServer();
   const port = server.address().port;
 
-  const res = await fetch(`http://localhost:${port}/git-file?repoUrl=/tmp/origin3.git&credentials=&file=readme.txt`, {
-    headers: { 'x-api-token': '' }
-  });
+  const res = await fetch(`http://localhost:${port}/git-file?repoUrl=/tmp/origin3.git&credentials=&file=readme.txt&x-api-token=`, {});
   assert.strictEqual(res.status, 200);
   const data = await res.json();
   assert.strictEqual(data.content.trim(), 'hello');


### PR DESCRIPTION
## Resumo
- aceita `x-api-token` via query string nas rotas
- atualiza documentação e ações do GPT
- ajusta testes para enviar o token na query

## Testes
- `npm test` *(falha: Express não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686d353bc144832c9a411cd4d6364d9d