### PR TITLE
Atualiza exemplos de Git e script de documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,30 @@ Permitem listar diret\u00f3rios e ler ou atualizar arquivos individuais.
 - `GET /git-file` obt\u00e9m o conte\u00fado de um arquivo (par\u00e2metros: `repoUrl`, `credentials`, `file`).
 - `PATCH /git-file` cria ou atualiza o arquivo e executa um commit.
 
+Exemplos de uso:
+
+```http
+GET /git-files?repoUrl=https://github.com/usuario/repositorio.git&credentials=usuario:token&path=docs
+```
+
+```http
+GET /git-file?repoUrl=https://github.com/usuario/repositorio.git&credentials=usuario:token&file=README.md
+```
+
+```http
+PATCH /git-file
+Headers:
+  x-api-token: <seu_token>
+
+{
+  "repoUrl": "https://github.com/usuario/repositorio.git",
+  "credentials": "usuario:token",
+  "filePath": "docs/novo.md",
+  "content": "# Novo conte\u00fado",
+  "commitMessage": "docs: atualiza arquivo"
+}
+```
+
 ## 🚀 Endpoint para Notion + Git
 
 Cria o conteúdo no Notion e salva o mesmo texto em um repositório Git.

--- a/src/doca.js
+++ b/src/doca.js
@@ -6,7 +6,10 @@ const specs = fs.readdirSync(gptDir)
   .map(f => JSON.parse(fs.readFileSync(path.join(gptDir, f), 'utf8')));
 const spec = specs.reduce((base, s) => {
   if (!base) return { ...s };
-  Object.assign(base.paths, s.paths);
+  for (const [route, methods] of Object.entries(s.paths)) {
+    base.paths[route] = base.paths[route] || {};
+    Object.assign(base.paths[route], methods);
+  }
   if (s.components && s.components.schemas) {
     base.components = base.components || { schemas: {} };
     base.components.schemas = {


### PR DESCRIPTION
## Resumo
- adiciona exemplos de uso das rotas `/git-files` e `/git-file`
- ajusta o gerador de docs para mesclar rotas duplicadas

## Testes
- `npm test` *(falha: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686d35873108832c9219daff70a77ee2