### PR TITLE
Unifica rota de conteúdo do Notion

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,16 +1,9 @@
 # API
 
-## POST /create-notion-content
+## POST /notion-content
 
-Envia o conteúdo dos resumos Notion informados no corpo.
-
-## POST /create-notion-flashcards
-
-Envia o conteúdo dos flashcards Notion informados no corpo.
-
-## POST /create-notion-cronograma
-
-Envia itens de cronograma para o Notion.
+Cria conteúdo no Notion de acordo com o campo `type` enviado no corpo
+(`resumo`, `flashcards` ou `cronograma`).
 
 ## GET /notion-content
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -9,60 +9,20 @@
     { "url": "https://me-passa-a-cola.onrender.com" }
   ],
   "paths": {
-    "/create-notion-content": {
+    "/notion-content": {
       "post": {
-        "operationId": "enviarResumos",
-        "description": "Envia o conteúdo dos resumos Notion informados no corpo.",
+        "operationId": "criarConteudoNotion",
+        "description": "Cria conteúdo no Notion conforme o tipo informado.",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotionContent"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": { "description": "Sucesso" }
-        }
-      }
-    },
-    "/create-notion-flashcards": {
-      "post": {
-        "operationId": "enviarFlashcards",
-        "description": "Envia o conteúdo dos flashcards Notion informados no corpo.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotionFlashcards"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": { "description": "Sucesso" }
-        }
-      }
-    },
-    "/create-notion-cronograma": {
-      "post": {
-        "operationId": "enviarCronograma",
-        "description": "Envia itens de cronograma para o Notion.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/NotionCronograma" }
+              "schema": { "$ref": "#/components/schemas/NotionContentUnified" }
             }
           }
         },
         "responses": { "200": { "description": "Sucesso" } }
-      }
-    },
-    "/notion-content": {
+      },
       "get": {
         "operationId": "buscarConteudoNotion",
         "description": "Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.",
@@ -552,6 +512,14 @@
           }
         },
         "required": ["tema", "cronograma", "notion_token"]
+      },
+      "NotionContentUnified": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "enum": ["resumo", "flashcards", "cronograma"] }
+        },
+        "required": ["type"],
+        "additionalProperties": true
       },
       "GitCommit": {
         "type": "object",

--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,7 @@ function parseGitHubRepo(url) {
     return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
 }
 
-// Endpoint principal
-app.post("/create-notion-content", async (req, res) => {
+async function createNotionResumo(req, res) {
     try {
         const {
             notion_token,
@@ -182,9 +181,9 @@ app.post("/create-notion-content", async (req, res) => {
         console.error(err);
         res.status(500).json({ error: err.message });
     }
-});
+}
 
-app.post("/create-notion-flashcards", async (req, res) => {
+async function createNotionFlashcards(req, res) {
     try {
         const {
             notion_token,
@@ -267,9 +266,9 @@ app.post("/create-notion-flashcards", async (req, res) => {
         console.error(err);
         res.status(500).json({ error: err.message });
     }
-});
+}
 
-app.post('/create-notion-cronograma', async (req, res) => {
+async function createNotionCronograma(req, res) {
     try {
         const {
             notion_token,
@@ -347,6 +346,16 @@ app.post('/create-notion-cronograma', async (req, res) => {
         console.error(err);
         res.status(500).json({ error: err.message });
     }
+}
+
+app.post('/notion-content', async (req, res) => {
+    const { type, ...body } = req.body || {};
+    if (!type) return res.status(400).json({ error: 'type é obrigatório' });
+    req.body = body;
+    if (type === 'resumo') return createNotionResumo(req, res);
+    if (type === 'flashcards') return createNotionFlashcards(req, res);
+    if (type === 'cronograma') return createNotionCronograma(req, res);
+    return res.status(400).json({ error: 'Tipo inválido' });
 });
 
 app.post('/pdf-to-notion', async (req, res) => {

--- a/tests/run.js
+++ b/tests/run.js
@@ -36,7 +36,7 @@ async function testBasicEndpoints() {
   const specRes = await fetch(`http://localhost:${port}/api-docs.json`);
   assert.strictEqual(specRes.status, 200);
   const spec = await specRes.json();
-  assert(spec.paths['/create-notion-content']);
+  assert(spec.paths['/notion-content']);
   assert(spec.paths['/github-issues']);
   assert(spec.paths['/github-projects']);
   assert(spec.paths['/github-projects/columns/cards']);


### PR DESCRIPTION
## Summary
- remover rotas individuais de criação de conteúdo
- criar rota única `POST /notion-content`
- atualizar documentação da API
- atualizar testes e especificação OpenAPI

## Testing
- `API_TOKEN= npm test` *(falha: refusing to merge unrelated histories)*

------
https://chatgpt.com/codex/tasks/task_e_686da42df2d0832c88104ec55e3e994f