### PR TITLE
Integra pdf em /notion-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,14 +478,15 @@ Exemplo de `.github/commit-template.md`:
 chore: atualiza documentos
 ```
 
-## 📄 Endpoint para PDF
+## 📄 Enviar PDF para o Notion
 
-Envia um arquivo PDF em base64 e registra o texto no Notion.
+Envia um arquivo PDF em base64, converte para Markdown e registra o texto usando `POST /notion-content` com `type` igual a `pdf`.
 
 ```http
-POST /pdf-to-notion
+POST /notion-content
 
 {
+  "type": "pdf",
   "notion_token": "secret_xxx",
   "nome_database": "Me Passa A Cola (GPT)",
   "tema": "Matéria X",
@@ -496,7 +497,7 @@ POST /pdf-to-notion
 }
 ```
 
-O PDF é convertido em Markdown antes de ser enviado ao Notion.
+O PDF é convertido em Markdown antes de ser salvo.
 
 ## 🧹 Endpoint para limpar tags órfãs
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,7 @@
 ## POST /notion-content
 
 Cria conteúdo no Notion de acordo com o campo `type` enviado no corpo
-(`resumo`, `flashcards` ou `cronograma`).
+(`resumo`, `flashcards`, `cronograma` ou `pdf`).
 
 ## GET /notion-content
 
@@ -38,10 +38,6 @@ Realiza commit em repositório privado usando token
 ## POST /create-notion-content-git
 
 Cria página no Notion e salva em repositório Git.
-
-## POST /pdf-to-notion
-
-Envia um PDF em base64 para conversão em Markdown e registro no Notion.
 
 ## POST /github-issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -454,14 +454,15 @@ Exemplo de `.github/commit-template.md`:
 chore: atualiza documentos
 ```
 
-## 📄 Endpoint para PDF
+## 📄 Enviar PDF para o Notion
 
-Envia um arquivo PDF em base64 e registra o texto no Notion.
+Envia um arquivo PDF em base64, converte para Markdown e registra o texto usando `POST /notion-content` com `type` igual a `pdf`.
 
 ```http
-POST /pdf-to-notion
+POST /notion-content
 
 {
+  "type": "pdf",
   "notion_token": "secret_xxx",
   "nome_database": "Me Passa A Cola (GPT)",
   "tema": "Matéria X",
@@ -472,7 +473,7 @@ POST /pdf-to-notion
 }
 ```
 
-O PDF é convertido em Markdown antes de ser enviado ao Notion.
+O PDF é convertido em Markdown antes de ser salvo.
 
 ## 🧹 Endpoint para limpar tags órfãs
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -155,21 +155,6 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/pdf-to-notion": {
-      "post": {
-        "operationId": "enviarPDF",
-        "description": "Envia um PDF em base64 para conversão em Markdown e registro no Notion.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/NotionPdf" }
-            }
-          }
-        },
-        "responses": { "200": { "description": "Sucesso" } }
-      }
-    },
     "/github-issues": {
       "post": {
         "operationId": "criarIssue",
@@ -516,7 +501,7 @@
       "NotionContentUnified": {
         "type": "object",
         "properties": {
-          "type": { "type": "string", "enum": ["resumo", "flashcards", "cronograma"] }
+          "type": { "type": "string", "enum": ["resumo", "flashcards", "cronograma", "pdf"] }
         },
         "required": ["type"],
         "additionalProperties": true
@@ -580,30 +565,6 @@
           "data": { "type": "string", "format": "date-time" }
         },
         "required": ["repoUrl", "credentials", "filePath", "notion_token", "resumo"]
-      },
-      "NotionPdf": {
-        "type": "object",
-        "properties": {
-          "notion_token": {
-            "type": "string",
-            "description": "Token da integração do Notion (ntn_...)"
-          },
-          "nome_database": {
-            "type": "string",
-            "description": "Nome Da Base"
-          },
-          "tema": { "type": "string" },
-          "subtitulo": { "type": "string" },
-          "pdf_base64": { "type": "string" },
-          "tags": { "type": "string" },
-          "data": { "type": "string", "format": "date-time" },
-          "destino": {
-            "type": "string",
-            "description": "Destino do envio: 'notion'",
-            "enum": ["notion"]
-          }
-        },
-        "required": ["destino", "pdf_base64"]
       },
       "AtualizarTitulosETags": {
         "type": "object",

--- a/gpt/prompt_auxiliar_projetos.md
+++ b/gpt/prompt_auxiliar_projetos.md
@@ -27,7 +27,7 @@ O "Auxiliar de Projetos" pode realizar as seguintes ações. O modelo deve infer
   - *Ferramentas:* `enviarResumos`, `enviarFlashcards`, `enviarCronograma`.
   - *Parâmetros a inferir:* `notion_token`, `nome_database` (padrão 'Me Passa A Cola (GPT)' ou nome do projeto), `tema` (nome do projeto/feature), `subtitulo` (tópico específico), `resumo`/`flashcards`/`cronograma` (conteúdo gerado), `tags`, `data`.
 - **Converter PDF e Registrar no Notion:** Recebe um arquivo em base64, converte para Markdown e salva na base do Notion.
-  - *Ferramenta:* `enviarPDF`.
+  - *Ferramenta:* `criarConteudoNotion` (use `type: 'pdf'`).
   - *Parâmetros a inferir:* `notion_token`, `nome_database`, `tema`, `subtitulo`, `pdf_base64`, `tags`, `data`.
 - **Versionar Artefatos e Documentações no Repositório (Git):** Realiza commits de arquivos e conteúdos.
   - *Ferramentas:* `gitCommit`, `criarNotionGit` (para conteúdo Notion que também deve ir para o Git).
@@ -106,6 +106,6 @@ O fluxo sugerido é:
 - Criar issue de autenticação via OAuth (`criarIssue`).
 - Resumir reunião e enviar ao Notion (`enviarResumos`).
 - Commit de documentação no repositório (`gitCommit`).
-- Enviar PDF para o Notion (`enviarPDF`).
+- Enviar PDF para o Notion (`criarConteudoNotion` com `type: 'pdf'`).
 - Abrir PR da nova feature (`criarPullRequest` ou `criarPrAutomatico`).
 

--- a/src/index.js
+++ b/src/index.js
@@ -348,17 +348,7 @@ async function createNotionCronograma(req, res) {
     }
 }
 
-app.post('/notion-content', async (req, res) => {
-    const { type, ...body } = req.body || {};
-    if (!type) return res.status(400).json({ error: 'type é obrigatório' });
-    req.body = body;
-    if (type === 'resumo') return createNotionResumo(req, res);
-    if (type === 'flashcards') return createNotionFlashcards(req, res);
-    if (type === 'cronograma') return createNotionCronograma(req, res);
-    return res.status(400).json({ error: 'Tipo inválido' });
-});
-
-app.post('/pdf-to-notion', async (req, res) => {
+async function createNotionPdf(req, res) {
     try {
         const {
             notion_token,
@@ -416,7 +406,20 @@ app.post('/pdf-to-notion', async (req, res) => {
         console.error(err);
         res.status(500).json({ error: err.message });
     }
+}
+
+app.post('/notion-content', async (req, res) => {
+    const { type, ...body } = req.body || {};
+    if (!type) return res.status(400).json({ error: 'type é obrigatório' });
+    req.body = body;
+    if (type === 'resumo') return createNotionResumo(req, res);
+    if (type === 'flashcards') return createNotionFlashcards(req, res);
+    if (type === 'cronograma') return createNotionCronograma(req, res);
+    if (type === 'pdf') return createNotionPdf(req, res);
+    return res.status(400).json({ error: 'Tipo inválido' });
 });
+
+// rota antiga removida em favor do tipo "pdf" dentro de /notion-content
 
 app.get("/notion-content", async (req, res) => {
     try {
@@ -673,10 +676,10 @@ app.get('/git-file', async (req, res) => {
         return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    const { repoUrl, credentials, file } = req.query;
+    const { repoUrl, credentials = '', file } = req.query;
 
-    if (!repoUrl || !credentials || !file) {
-        return res.status(400).json({ error: 'repoUrl, credentials e file são obrigatórios' });
+    if (!repoUrl || !file) {
+        return res.status(400).json({ error: 'repoUrl e file são obrigatórios' });
     }
 
     try {

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -10,11 +10,10 @@ async function cloneRepo(repoUrl, credentials) {
     const repoPath = path.join('/tmp', repoName);
     const git = simpleGit();
 
-    if (!fs.existsSync(repoPath)) {
-        await git.clone(authUrl, repoPath);
-    } else {
-        await simpleGit(repoPath).pull();
+    if (fs.existsSync(repoPath)) {
+        fs.rmSync(repoPath, { recursive: true, force: true });
     }
+    await git.clone(authUrl, repoPath);
 
     return repoPath;
 }

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,3 +1,4 @@
+process.env.API_TOKEN = 'testtoken';
 const { app } = require('../src/index');
 const { cloneRepo } = require('../src/utils/git');
 const assert = require('assert');
@@ -25,10 +26,10 @@ async function testBasicEndpoints() {
   const server = startServer();
   const port = server.address().port;
 
-  const res = await fetch(`http://localhost:${port}/pdf-to-notion`, {
+  const res = await fetch(`http://localhost:${port}/notion-content`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({})
+    body: JSON.stringify({ type: 'pdf' })
   });
 
   assert.strictEqual(res.status, 400);
@@ -77,7 +78,7 @@ async function testGitFileRoute() {
   const server = startServer();
   const port = server.address().port;
 
-  const res = await fetch(`http://localhost:${port}/git-file?repoUrl=/tmp/origin3.git&credentials=&file=readme.txt&x-api-token=`, {});
+  const res = await fetch(`http://localhost:${port}/git-file?repoUrl=/tmp/origin3.git&credentials=&file=readme.txt&x-api-token=testtoken`, {});
   assert.strictEqual(res.status, 200);
   const data = await res.json();
   assert.strictEqual(data.content.trim(), 'hello');


### PR DESCRIPTION
## Resumo
- migrar rota `/pdf-to-notion` para dentro de `/notion-content` usando `type: "pdf"`
- remover endpoint antigo do `actions.json`
- atualizar documentação e prompts
- ajustar testes e utilitário git

## Testes
- `npm test` *(falhou: fetch failed e outros problemas de rede)*

------
https://chatgpt.com/codex/tasks/task_e_686da78cbfa4832c8e5f5c5d1b3a3aba