### PR TITLE
Atualiza rota git-file e remove git-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,32 +313,6 @@ POST /atualizar-titulos-e-tags
 ```
 
 
-## 🚀 Endpoint de Commit no Git
-
-A API disponibiliza a rota `POST /git-commit` para realizar commits em repositórios privados utilizando um token de acesso.
-
-### Requisição
-
-```http
-POST /git-commit?x-api-token=<seu_token>
-
-{
-  "repoUrl": "https://github.com/usuario/repositorio.git",
-  "credentials": "ghp_xxx",
-  "message": "feat: meu commit",
-  "files": ["arquivo.txt"],
-  "branch": "main",  # opcional
-  "content": {
-  "novo.txt": "conteudo gerado"
-  }
-  "githubToken": "ghp_xxx",      # opcional para disparar workflow
-  "githubOwner": "usuario",      # opcional
-  "githubRepo": "repositorio"    # opcional
-}
-```
-
-O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo parâmetro de query `x-api-token`.
-Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
 ## \ud83d\udcc2 Endpoints para arquivos do Git
 
@@ -346,7 +320,7 @@ Permitem listar diret\u00f3rios e ler ou atualizar arquivos individuais.
 
 - `GET /git-files` lista arquivos de um caminho (par\u00e2metros: `repoUrl`, `credentials`, `path`).
 - `GET /git-file` obt\u00e9m o conte\u00fado de um arquivo (par\u00e2metros: `repoUrl`, `credentials`, `file`).
-- `PATCH /git-file` cria ou atualiza o arquivo e executa um commit.
+- `PATCH /git-file` cria ou atualiza arquivos e executa um commit.
 
 Exemplos de uso:
 
@@ -366,9 +340,11 @@ Headers:
 {
   "repoUrl": "https://github.com/usuario/repositorio.git",
   "credentials": "usuario:token",
-  "filePath": "docs/novo.md",
-  "content": "# Novo conte\u00fado",
-  "commitMessage": "docs: atualiza arquivo"
+  "content": {
+    "docs/novo.md": "# Novo conte\u00fado",
+    "docs/outro.md": "Outro texto"
+  },
+  "commitMessage": "docs: atualiza"
 }
 ```
 
@@ -403,7 +379,7 @@ As tags informadas são combinadas com tags geradas automaticamente a partir do 
 
 Antes de iniciar a API é preciso definir algumas variáveis no ambiente:
 
-- `API_TOKEN`: usada para autenticação em `/git-commit`.
+- `API_TOKEN`: usada para autenticação nas rotas de Git.
 - `PORT` (opcional, padrão `3333`).
 
 Você pode exportá-las no terminal ou criar um arquivo `.env` na raiz do projeto.

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,11 +29,7 @@ Retorna o conteúdo de um arquivo do repositório.
 
 ## PATCH /git-file
 
-Atualiza ou cria um arquivo e realiza commit.
-
-## POST /git-commit
-
-Realiza commit em repositório privado usando token
+Atualiza ou cria arquivos e realiza commit.
 
 ## POST /create-notion-content-git
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -313,32 +313,6 @@ POST /atualizar-titulos-e-tags
 ```
 
 
-## 🚀 Endpoint de Commit no Git
-
-A API disponibiliza a rota `POST /git-commit` para realizar commits em repositórios privados utilizando um token de acesso.
-
-### Requisição
-
-```http
-POST /git-commit?x-api-token=<seu_token>
-
-{
-  "repoUrl": "https://github.com/usuario/repositorio.git",
-  "credentials": "ghp_xxx",
-  "message": "feat: meu commit",
-  "files": ["arquivo.txt"],
-  "branch": "main",  # opcional
-  "content": {
-  "novo.txt": "conteudo gerado"
-  }
-  "githubToken": "ghp_xxx",      # opcional para disparar workflow
-  "githubOwner": "usuario",      # opcional
-  "githubRepo": "repositorio"    # opcional
-}
-```
-
-O campo `branch` é opcional e assume `main` como padrão. Os caminhos listados em `files` são relativos ao repositório. O objeto `content` permite criar arquivos fornecendo pares caminho/conteúdo. O acesso é protegido pelo parâmetro de query `x-api-token`.
-Se o arquivo `.cola-config` contiver `commitWorkflow`, esse workflow será disparado após o commit usando as credenciais informadas.
 
 ## \ud83d\udcc2 Endpoints para arquivos do Git
 
@@ -346,7 +320,7 @@ Permitem listar diret\u00f3rios e ler ou atualizar arquivos individuais.
 
 - `GET /git-files` lista arquivos de um caminho (par\u00e2metros: `repoUrl`, `credentials`, `path`).
 - `GET /git-file` obt\u00e9m o conte\u00fado de um arquivo (par\u00e2metros: `repoUrl`, `credentials`, `file`).
-- `PATCH /git-file` cria ou atualiza o arquivo e executa um commit.
+- `PATCH /git-file` cria ou atualiza arquivos e executa um commit.
 
 ## 🚀 Endpoint para Notion + Git
 
@@ -379,7 +353,7 @@ As tags informadas são combinadas com tags geradas automaticamente a partir do 
 
 Antes de iniciar a API é preciso definir algumas variáveis no ambiente:
 
-- `API_TOKEN`: usada para autenticação em `/git-commit`.
+- `API_TOKEN`: usada para autenticação nas rotas de Git.
 - `PORT` (opcional, padrão `3333`).
 
 Você pode exportá-las no terminal ou criar um arquivo `.env` na raiz do projeto.

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -109,29 +109,6 @@
         "responses": { "200": { "description": "Sucesso" } }
       }
     },
-    "/git-commit": {
-      "post": {
-        "operationId": "gitCommit",
-        "description": "Realiza commit em repositório privado usando token",
-        "parameters": [
-          {
-            "name": "x-api-token",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/GitCommit" }
-            }
-          }
-        },
-        "responses": { "200": { "description": "Sucesso" } }
-      }
-    },
     "/create-notion-content-git": {
       "post": {
         "operationId": "criarNotionGit",
@@ -506,27 +483,6 @@
         "required": ["type"],
         "additionalProperties": true
       },
-      "GitCommit": {
-        "type": "object",
-        "properties": {
-          "repoUrl": { "type": "string" },
-          "credentials": { "type": "string" },
-          "message": { "type": "string" },
-          "files": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
-          "branch": {
-            "type": "string",
-            "description": "Nome do branch (padr\u00e3o 'main')"
-          },
-          "content": {
-            "type": "object",
-            "additionalProperties": { "type": "string" }
-          }
-        },
-        "required": ["repoUrl", "credentials"]
-  },
 
       "GitFileUpdate": {
         "type": "object",
@@ -534,14 +490,15 @@
           "repoUrl": { "type": "string" },
           "credentials": { "type": "string" },
           "filePath": { "type": "string" },
-          "content": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "string" } },
+          "content": { "type": "object", "additionalProperties": { "type": "string" } },
           "commitMessage": { "type": "string" },
           "branch": { "type": "string" },
           "githubToken": { "type": "string" },
           "githubOwner": { "type": "string" },
           "githubRepo": { "type": "string" }
         },
-        "required": ["repoUrl", "credentials", "filePath", "content"]
+        "required": ["repoUrl", "credentials", "content"]
       },
       "NotionContentGit": {
         "type": "object",


### PR DESCRIPTION
## Resumo
- aceita múltiplos arquivos em `PATCH /git-file`
- remove rota `/git-commit`
- atualiza documentação e ações do GPT
- ajusta testes

## Testes
- `npm install`
- `npm test` *(falhou: undefined !== 2)*

------
https://chatgpt.com/codex/tasks/task_e_686dabb3d410832cba3df0fee6aa141d