### PR TITLE
Adicionar paginação às rotas do GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,8 +536,9 @@ Para fechar, envie `state: "closed"`.
 ### Listar Issues
 
 ```http
-GET /github-issues?token=ghp_xxx&owner=usuario&repo=repositorio&state=open
+GET /github-issues?token=ghp_xxx&owner=usuario&repo=repositorio&state=open&page=1&per_page=30
 ```
+Defina `page` e `per_page` para controlar a paginação.
 
 ### Criar Label
 
@@ -626,8 +627,9 @@ POST /github-projects/columns/cards
 ### Listar Projetos
 
 ```http
-GET /github-projects?token=ghp_xxx&owner=usuario&repo=repositorio
+GET /github-projects?token=ghp_xxx&owner=usuario&repo=repositorio&cursor=
 ```
+Use o valor de `cursor` retornado anteriormente para acessar a próxima página.
 
 ### Listar Colunas do Projeto
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@ do arquivo `.cola-config` são utilizados, quando presentes.
 
 ## GET /github-issues
 
-Lista issues do repositório
+Lista issues do repositório. Suporta paginação usando `page` e `per_page`.
 
 ## PATCH /github-issues
 
@@ -79,8 +79,7 @@ Atualiza uma milestone
 Cria um projeto via GraphQL
 
 ## GET /github-projects
-
-Lista projetos do repositório
+Lista projetos do repositório. Para navegar, envie o parâmetro `cursor` retornado pela página anterior.
 
 ## POST /github-projects/columns
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -150,7 +150,9 @@
           { "name": "owner", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "repo", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "state", "in": "query", "required": false, "schema": { "type": "string", "default": "open" } },
-          { "name": "labels", "in": "query", "required": false, "schema": { "type": "string" } }
+          { "name": "labels", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "page", "in": "query", "required": false, "schema": { "type": "integer" } },
+          { "name": "per_page", "in": "query", "required": false, "schema": { "type": "integer" } }
         ],
         "responses": { "200": { "description": "Sucesso" } }
       },
@@ -244,7 +246,8 @@
         "parameters": [
           { "name": "token", "in": "query", "required": true, "schema": { "type": "string" } },
           { "name": "owner", "in": "query", "required": true, "schema": { "type": "string" } },
-          { "name": "repo", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "repo", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } }
         ],
         "responses": { "200": { "description": "Sucesso" } }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1006,12 +1006,12 @@ app.patch('/github-issues', async (req, res) => {
 });
 
 app.get('/github-issues', async (req, res) => {
-    const { token, owner, repo, state = 'open', labels = '' } = req.query;
+    const { token, owner, repo, state = 'open', labels = '', page, per_page } = req.query;
     if (!token || !owner || !repo) {
         return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
     }
     try {
-        const issues = await listIssues({ token, owner, repo, state, labels });
+        const issues = await listIssues({ token, owner, repo, state, labels, page, per_page });
         res.json({ ok: true, issues });
     } catch (err) {
         console.error(err);
@@ -1118,12 +1118,12 @@ app.post('/github-projects/columns/cards', async (req, res) => {
 });
 
 app.get('/github-projects', async (req, res) => {
-    const { token, owner, repo } = req.query;
+    const { token, owner, repo, cursor } = req.query;
     if (!token || !owner || !repo) {
         return res.status(400).json({ error: 'token, owner e repo são obrigatórios' });
     }
     try {
-        const projects = await listProjects({ token, owner, repo });
+        const projects = await listProjects({ token, owner, repo, cursor });
         res.json({ ok: true, projects });
     } catch (err) {
         console.error(err);

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -72,8 +72,11 @@ async function closeIssue(params) {
     return updateIssue({ ...params, state: 'closed' });
 }
 
-async function listIssues({ token, owner, repo, state = 'open', labels = '' }) {
-    const searchParams = new URLSearchParams({ state, labels });
+async function listIssues({ token, owner, repo, state = 'open', labels = '', page, per_page }) {
+    const params = { state, labels };
+    if (page !== undefined) params.page = page;
+    if (per_page !== undefined) params.per_page = per_page;
+    const searchParams = new URLSearchParams(params);
     return githubRequest(token, 'GET', `/repos/${owner}/${repo}/issues?${searchParams.toString()}`);
 }
 
@@ -120,9 +123,9 @@ async function createProjectColumn({ token, project_id, name }) {
     return result.data.addProjectColumn.columnEdge.node;
 }
 
-async function listProjects({ token, owner, repo }) {
-    const query = `query ($owner: String!, $name: String!) {\n  repository(owner: $owner, name: $name) {\n    projects(first: 100) { nodes { id name body } }\n  }\n}`;
-    const result = await githubGraphqlRequest(token, query, { owner, name: repo });
+async function listProjects({ token, owner, repo, cursor }) {
+    const query = `query ($owner: String!, $name: String!, $cursor: String) {\n  repository(owner: $owner, name: $name) {\n    projects(first: 100, after: $cursor) { nodes { id name body } }\n  }\n}`;
+    const result = await githubGraphqlRequest(token, query, { owner, name: repo, cursor });
     return result.data.repository.projects.nodes;
 }
 


### PR DESCRIPTION
## Resumo
- permitir paginação em `listIssues` e `listProjects`
- repassar parâmetros de paginação nas rotas da API
- documentar o uso de `page`/`per_page` e `cursor`
- atualizar OpenAPI para refletir os novos parâmetros

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703716be74832c99b9dd1d2bb35ddb