### PR TITLE
Implementar paginação em /notion-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,17 +273,18 @@ Consulta conteúdos registrados no Notion.
 - `subtitulo` (opcional)
 - `tipo` (opcional)
 - `limit` (opcional)
+- `start_cursor` (opcional)
 
 **Exemplo**
 
 ```
-GET /notion-content?notion_token=secret_xxx&tema=Matéria%20X&limit=5
+GET /notion-content?notion_token=secret_xxx&tema=Matéria%20X&limit=5&start_cursor=XYZ
 ```
 
 **Resposta**
 
 ```json
-{ "ok": true, "results": [] }
+{ "ok": true, "next_cursor": null, "results": [] }
 ```
 
 ### POST /atualizar-titulos-e-tags

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ Cria conteúdo no Notion de acordo com o campo `type` enviado no corpo
 
 ## GET /notion-content
 
-Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.
+Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo. Aceita o parâmetro `start_cursor` para paginação e retorna `next_cursor` na resposta.
 
 ## POST /atualizar-titulos-e-tags
 


### PR DESCRIPTION
## Resumo
- aceitar `start_cursor` no endpoint GET `/notion-content`
- repassar o cursor ao `notion.databases.query`
- enviar `next_cursor` na resposta
- documentar nova páginação no README e em `docs/API.md`

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703d5a5678832c8f996b1df68cab7e