### PR TITLE
Add cache pagination tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.cache.json


### PR DESCRIPTION
## Summary
- ignore `.cache.json`
- test GitHub pagination, caching and TTL

## Testing
- `npx -y -p node@18 node tests/run.js >/tmp/test.log 2>&1 && tail -n 2 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6870509cf21c832ca92aed2756765610