### PR TITLE
Update GPT prompts and docs for cache TTL

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ Cria conteúdo no Notion de acordo com o campo `type` enviado no corpo
 
 ## GET /notion-content
 
-Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo. Aceita o parâmetro `start_cursor` para paginação e retorna `next_cursor` na resposta.
+Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo. Aceita os parâmetros `start_cursor` (paginação) e `ttl` (cache em segundos). Retorna `next_cursor` na resposta.
 
 ## POST /atualizar-titulos-e-tags
 

--- a/gpt/actions.json
+++ b/gpt/actions.json
@@ -32,7 +32,9 @@
           { "name": "tema", "in": "query", "required": false, "schema": { "type": "string" } },
           { "name": "subtitulo", "in": "query", "required": false, "schema": { "type": "string" } },
           { "name": "tipo", "in": "query", "required": false, "schema": { "type": "string" } },
-          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 } }
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 } },
+          { "name": "start_cursor", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "ttl", "in": "query", "required": false, "schema": { "type": "integer" }, "description": "Tempo de cache em segundos" }
         ],
         "responses": { "200": { "description": "Sucesso" } }
       }

--- a/gpt/prompt.md
+++ b/gpt/prompt.md
@@ -215,6 +215,8 @@ O endpoint `/atualizar-titulos-e-tags` revisa as subpáginas de um tema e ajusta
 - Flashcards são enviados como subpáginas com blocos separados para pergunta/resposta
 - Campos opcionais são ignorados se não enviados
 - Em caso de erro, até 3 tentativas são feitas com log da falha
+- As requisições podem usar cache local (`.cache.json`). Defina `CACHE_TTL` ou envie `ttl` no endpoint `/notion-content` para controlar o tempo de expiração.
+- Para grandes volumes de dados use a paginação disponível (`page`/`per_page`, `cursor` ou `start_cursor`).
 
 
 ## 🔗 Links

--- a/gpt/prompt_auxiliar_projetos.md
+++ b/gpt/prompt_auxiliar_projetos.md
@@ -15,6 +15,7 @@ Atuar como um **auxiliar de projetos** multifuncional, unindo as visões de Scru
 - Utilize todas as funcionalidades e ferramentas descritas neste prompt para apoiar o usuário.
 - Priorize sempre os endpoints definidos em `actions.json` em vez de integrações nativas do ChatGPT ou de terceiros.
 - Quando o usuário conceder permissão para usar um endpoint ou fornecer um token, considere essa autorização válida para toda a sessão e não solicite novamente.
+- Utilize o cache local (`.cache.json`) para evitar chamadas repetidas quando `CACHE_TTL` ou o parâmetro `ttl` estiverem configurados. Explore a paginação (`page`, `per_page`, `cursor`, `start_cursor`) para resultados extensos.
 
 ## 📋 Atividades Principais e Uso Inteligente de Ferramentas
 


### PR DESCRIPTION
## Descrição
Atualiza prompts e `actions.json` para refletir o suporte a TTL e paginação, além de inserir nota na documentação da API.

## Tipo de mudança
- [ ] Chore
- [x] Melhoria de documentação
- [ ] Outros (descreva)

## Issue relacionada

<!-- Se houver, cite a issue que este PR resolve -->

## Checklist
- [x] Meu código segue as diretrizes do projeto
- [x] Realizei testes locais
- [x] Atualizei a documentação quando necessário

------
https://chatgpt.com/codex/tasks/task_e_687878eed08c832cbea402a55ffc6510