### PR TITLE
docs: corrigir tempo de espera do deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ o cache apenas daquela chamada específica.
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o
 deploy no Render está ativo. O arquivo
-`.github/workflows/render-deploy-and-check.yml` espera 45&nbsp;segundos antes de
+`.github/workflows/render-deploy-and-check.yml` espera 60&nbsp;segundos antes de
 fazer uma requisição para `https://me-passa-a-cola.onrender.com/health`. Se a
 resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
 produção.

--- a/docs/index.md
+++ b/docs/index.md
@@ -737,7 +737,7 @@ o cache apenas daquela chamada.
 
 O repositório conta com um workflow do **GitHub Actions** que monitora se o
 deploy no Render está ativo. O arquivo
-`.github/workflows/render-deploy-and-check.yml` espera 45&nbsp;segundos antes de
+`.github/workflows/render-deploy-and-check.yml` espera 60&nbsp;segundos antes de
 fazer uma requisição para `https://me-passa-a-cola.onrender.com/health`. Se a
 resposta não for `200`, o workflow falha e sinaliza um problema no ambiente de
 produção.


### PR DESCRIPTION
## Descrição
Atualiza README e docs para refletirem o tempo correto de espera (60s) antes da verificação de deploy no workflow.

## Tipo de mudança
- [ ] Correção de bug
- [x] Melhoria de documentação
- [ ] Outros (descreva)

## Issue relacionada

<!-- Se houver, cite a issue que este PR resolve -->

## Checklist
- [x] Meu código segue as diretrizes do projeto
- [x] Realizei testes locais
- [x] Atualizei a documentação quando necessário

------
https://chatgpt.com/codex/tasks/task_e_68824ec62700832ca2e640951ac24135