### PR TITLE
docs: gerar API automaticamente

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,20 @@
+name: Generate API Docs
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'gpt/actions.json'
+      - 'gpt/prompts.json'
+      - 'scripts/generate-docs.js'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run docs

--- a/README.md
+++ b/README.md
@@ -728,10 +728,11 @@ POST /linear-issues/project
 }
 ```
 
-## 📚 Documentação com Doca
+## 📚 Documentação da API
 
-Execute `npm run doca` para gerar a documentação da API em `docs/API.md`.
-Depois de iniciar o servidor, acesse `http://localhost:3333/doca/API.md` para visualizar.
+Execute `npm run docs` para gerar `docs/API.md` a partir de `gpt/actions.json` e `gpt/prompts.json`.
+Se preferir, inicie o servidor e acesse `http://localhost:3333/doca/API.md` para visualizar a versão antiga.
+Um workflow chamado **Generate API Docs** também pode ser disparado manualmente para atualizar a documentação automaticamente.
 
 ### Ações para GPT personalizado
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,127 +1,355 @@
 # API
 
-## POST /notion-content
+## Sumário
+- [POST /notion-content](#postnotioncontent)
+- [GET /notion-content](#getnotioncontent)
+- [POST /atualizar-titulos-e-tags](#postatualizartitulosetags)
+- [POST /limpar-tags-orfas](#postlimpartagsorfas)
+- [GET /git-files](#getgitfiles)
+- [GET /git-file](#getgitfile)
+- [PATCH /git-file](#patchgitfile)
+- [POST /create-notion-content-git](#postcreatenotioncontentgit)
+- [POST /github-issues](#postgithubissues)
+- [GET /github-issues](#getgithubissues)
+- [PATCH /github-issues](#patchgithubissues)
+- [POST /github-workflows](#postgithubworkflows)
+- [GET /github-workflows](#getgithubworkflows)
+- [POST /github-labels](#postgithublabels)
+- [POST /github-milestones](#postgithubmilestones)
+- [GET /github-milestones](#getgithubmilestones)
+- [PATCH /github-milestones](#patchgithubmilestones)
+- [POST /github-projects](#postgithubprojects)
+- [GET /github-projects](#getgithubprojects)
+- [POST /github-projects/columns](#postgithubprojectscolumns)
+- [GET /github-projects/columns](#getgithubprojectscolumns)
+- [POST /github-projects/columns/cards](#postgithubprojectscolumnscards)
+- [POST /github-pulls](#postgithubpulls)
+- [PATCH /github-pulls](#patchgithubpulls)
+- [POST /linear-issues/project](#postlinearissuesproject)
 
-Cria conteúdo no Notion de acordo com o campo `type` enviado no corpo
-(`resumo`, `flashcards`, `cronograma` ou `pdf`).
+### <a id="postnotioncontent"></a> POST /notion-content
 
-## GET /notion-content
+Cria conteúdo no Notion conforme o tipo informado.
 
-Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo. Aceita os parâmetros `start_cursor` (paginação) e `ttl` (cache em segundos). Retorna `next_cursor` na resposta.
+Corpo da requisição:
+- `type` (string) (obrigatório)
 
-## POST /atualizar-titulos-e-tags
-
-Atualiza títulos e tags das subpáginas de um tema no Notion.
-
-## POST /limpar-tags-orfas
-
-Remove tags não utilizadas do banco de dados.
-
-
-## GET /git-files
-
-Lista os arquivos de um diretório do repositório.
-
-## GET /git-file
-
-
-Retorna o conteúdo de um arquivo do repositório.
-
-## PATCH /git-file
-
-Atualiza ou cria arquivos e realiza commit.
-
-## POST /create-notion-content-git
-
-Cria página no Notion e salva em repositório Git.
-
-## POST /github-issues
-
-Cria uma issue no GitHub.
-Se `milestone` ou `column_id` não forem enviados,
-os valores `defaultIssueMilestone`, `defaultIssueProject` e `defaultIssueColumn`
-do arquivo `.cola-config` são utilizados, quando presentes.
-
-## GET /github-issues
-
-Lista issues do repositório. Suporta paginação usando `page` e `per_page`.
-
-## PATCH /github-issues
-
-Atualiza uma issue existente. Envie `state: "closed"` para fechar.
-
-## POST /github-workflows
-
-Dispara um workflow no GitHub
-
-## GET /github-workflows
-
-Consulta o status de um workflow run
-
-## POST /github-labels
-
-Cria uma label no repositório
-
-## POST /github-milestones
-
-Cria uma milestone
-
-## GET /github-milestones
-
-Lista milestones do repositório
-
-## PATCH /github-milestones
-
-Atualiza uma milestone
-
-## POST /github-projects
-
-Cria um projeto via GraphQL
-
-## GET /github-projects
-Lista projetos do repositório. Para navegar, envie o parâmetro `cursor` retornado pela página anterior.
-
-## POST /github-projects/columns
-
-Cria coluna em um projeto via GraphQL
-
-> **Nota**: se a resposta do GitHub contiver `errors`, o serviço retorna
-> a mensagem de erro fornecida pela API.
-
-## GET /github-projects/columns
-
-Lista colunas de um projeto
-
-## POST /github-projects/columns/cards
-
-Adiciona issue ao projeto via GraphQL (use o `node_id` da issue)
-
-## POST /github-pulls
-
-Cria um pull request. Se `merge: true` (ou `auto: true`) for enviado no corpo, o PR será mesclado automaticamente. Utilize `autoClose: true` para fechar o PR após o merge.
-
-```http
-POST /github-pulls
-
+Exemplo:
+```json
 {
-  "token": "ghp_xxx",
-  "owner": "usuario",
-  "repo": "repositorio",
-  "head": "feature-branch",
-  "base": "main",
-  "repoUrl": "https://github.com/usuario/repositorio.git",
-  "credentials": "usuario:token",
-  "type": "feature",
-  "merge": true,
-  "autoClose": true
+  "notion_token": "seu_token",
+  "nome_database": "Me Passa A Cola (GPT)",
+  "tema": "Matemática",
+  "type": "resumo",
+  "resumo": "Conteúdo gerado"
 }
 ```
 
-## PATCH /github-pulls
+### <a id="getnotioncontent"></a> GET /notion-content
 
-Atualiza, fecha ou mescla um pull request. Envie `merge: true` (ou `auto: true`) para realizar o merge. Para apenas fechar, use `close: true` ou `state: 'closed'`.
+Busca conteúdos já registrados no Notion usando filtros de tema, subtítulo ou tipo.
 
-## POST /linear-issues/project
+Parâmetros:
+- `notion_token` (query, string) (obrigatório)
+- `nome_database` (query, string)
+- `tema` (query, string)
+- `subtitulo` (query, string)
+- `tipo` (query, string)
+- `limit` (query, integer)
+- `start_cursor` (query, string)
+- `ttl` (query, integer) - Tempo de cache em segundos
+
+### <a id="postatualizartitulosetags"></a> POST /atualizar-titulos-e-tags
+
+Atualiza títulos e tags das subpáginas de um tema no Notion.
+
+Corpo da requisição:
+- `notion_token` (string) (obrigatório)
+- `nome_database` (string)
+- `tema` (string) (obrigatório)
+
+### <a id="postlimpartagsorfas"></a> POST /limpar-tags-orfas
+
+Remove tags não utilizadas do banco de dados.
+
+Corpo da requisição:
+- `notion_token` (string) (obrigatório)
+- `nome_database` (string)
+
+### <a id="getgitfiles"></a> GET /git-files
+
+Lista os arquivos de um diretório do repositório
+
+Parâmetros:
+- `x-api-token` (query, string) (obrigatório)
+- `repoUrl` (query, string) (obrigatório)
+- `credentials` (query, string) (obrigatório)
+- `path` (query, string)
+
+### <a id="getgitfile"></a> GET /git-file
+
+Retorna o conteúdo de um arquivo
+
+Parâmetros:
+- `x-api-token` (query, string) (obrigatório)
+- `repoUrl` (query, string) (obrigatório)
+- `credentials` (query, string) (obrigatório)
+- `file` (query, string) (obrigatório)
+
+### <a id="patchgitfile"></a> PATCH /git-file
+
+Atualiza ou cria um arquivo e realiza commit
+
+Parâmetros:
+- `x-api-token` (query, string) (obrigatório)
+
+Corpo da requisição:
+- `repoUrl` (string) (obrigatório)
+- `credentials` (string) (obrigatório)
+- `filePath` (string)
+- `files` (array)
+- `content` (object) (obrigatório)
+- `commitMessage` (string)
+- `branch` (string)
+- `githubToken` (string)
+- `githubOwner` (string)
+- `githubRepo` (string)
+
+### <a id="postcreatenotioncontentgit"></a> POST /create-notion-content-git
+
+Cria página no Notion e salva em repositório Git.
+
+Parâmetros:
+- `x-api-token` (query, string) (obrigatório)
+
+Corpo da requisição:
+- `repoUrl` (string) (obrigatório)
+- `credentials` (string) (obrigatório)
+- `commitMessage` (string)
+- `filePath` (string) (obrigatório)
+- `branch` (string)
+- `notion_token` (string) (obrigatório)
+- `nome_database` (string)
+- `tema` (string)
+- `subtitulo` (string)
+- `tipo` (string)
+- `resumo` (string) (obrigatório)
+- `observacoes` (string)
+- `tags` (string)
+- `data` (string)
+
+### <a id="postgithubissues"></a> POST /github-issues
+
+Cria uma issue no GitHub
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `title` (string) (obrigatório)
+- `body` (string)
+- `labels` (undefined)
+- `assignees` (undefined)
+- `milestone` (undefined)
+- `column_id` (integer)
+
+### <a id="getgithubissues"></a> GET /github-issues
+
+Lista issues do repositório
+
+Parâmetros:
+- `token` (query, string) (obrigatório)
+- `owner` (query, string) (obrigatório)
+- `repo` (query, string) (obrigatório)
+- `state` (query, string)
+- `labels` (query, string)
+- `page` (query, integer)
+- `per_page` (query, integer)
+
+Exemplo:
+```json
+{
+  "token": "ghp_xxx",
+  "owner": "usuario",
+  "repo": "repositorio"
+}
+```
+
+### <a id="patchgithubissues"></a> PATCH /github-issues
+
+Atualiza uma issue existente ou fecha quando `state` é `closed`
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `number` (integer) (obrigatório)
+- `title` (string)
+- `body` (string)
+- `state` (string)
+- `labels` (undefined)
+- `assignees` (undefined)
+- `milestone` (undefined)
+
+### <a id="postgithubworkflows"></a> POST /github-workflows
+
+Dispara um workflow no GitHub
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `workflow_id` (string) (obrigatório)
+- `ref` (string)
+- `inputs` (object)
+
+### <a id="getgithubworkflows"></a> GET /github-workflows
+
+Consulta o status de um workflow run
+
+Parâmetros:
+- `token` (query, string) (obrigatório)
+- `owner` (query, string) (obrigatório)
+- `repo` (query, string) (obrigatório)
+- `run_id` (query, string) (obrigatório)
+
+### <a id="postgithublabels"></a> POST /github-labels
+
+Cria uma label no repositório
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `name` (string) (obrigatório)
+- `color` (string)
+- `description` (string)
+
+### <a id="postgithubmilestones"></a> POST /github-milestones
+
+Cria uma milestone
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `title` (string) (obrigatório)
+- `state` (string)
+- `description` (string)
+- `due_on` (string)
+
+### <a id="getgithubmilestones"></a> GET /github-milestones
+
+Lista milestones do repositório
+
+Parâmetros:
+- `token` (query, string) (obrigatório)
+- `owner` (query, string) (obrigatório)
+- `repo` (query, string) (obrigatório)
+- `state` (query, string)
+
+### <a id="patchgithubmilestones"></a> PATCH /github-milestones
+
+Atualiza uma milestone
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `number` (integer) (obrigatório)
+- `title` (string)
+- `state` (string)
+- `description` (string)
+- `due_on` (string)
+
+### <a id="postgithubprojects"></a> POST /github-projects
+
+Cria um projeto via GraphQL
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `name` (string) (obrigatório)
+- `body` (string)
+
+### <a id="getgithubprojects"></a> GET /github-projects
+
+Lista projetos do repositório
+
+Parâmetros:
+- `token` (query, string) (obrigatório)
+- `owner` (query, string) (obrigatório)
+- `repo` (query, string) (obrigatório)
+- `cursor` (query, string)
+
+### <a id="postgithubprojectscolumns"></a> POST /github-projects/columns
+
+Cria coluna em um projeto via GraphQL
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `project_id` (string) (obrigatório)
+- `name` (string) (obrigatório)
+
+### <a id="getgithubprojectscolumns"></a> GET /github-projects/columns
+
+Lista colunas de um projeto
+
+Parâmetros:
+- `token` (query, string) (obrigatório)
+- `project_id` (query, string) (obrigatório)
+
+### <a id="postgithubprojectscolumnscards"></a> POST /github-projects/columns/cards
+
+Adiciona issue ao projeto via GraphQL
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `column_id` (string) (obrigatório)
+- `issue_id` (string) (obrigatório)
+
+### <a id="postgithubpulls"></a> POST /github-pulls
+
+Cria um pull request e pode mesclar automaticamente
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `title` (string)
+- `head` (string) (obrigatório)
+- `base` (string)
+- `body` (string)
+- `repoUrl` (string)
+- `credentials` (string)
+- `type` (string)
+- `merge` (boolean)
+- `auto` (boolean)
+- `autoClose` (boolean)
+
+### <a id="patchgithubpulls"></a> PATCH /github-pulls
+
+Atualiza, fecha ou mescla um pull request
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `owner` (string) (obrigatório)
+- `repo` (string) (obrigatório)
+- `number` (integer) (obrigatório)
+- `title` (string)
+- `body` (string)
+- `state` (string)
+- `merge` (boolean)
+- `auto` (boolean)
+- `close` (boolean)
+
+### <a id="postlinearissuesproject"></a> POST /linear-issues/project
 
 Atualiza o projeto de uma issue no Linear
+
+Corpo da requisição:
+- `token` (string) (obrigatório)
+- `issue_id` (string) (obrigatório)
+- `project_id` (string) (obrigatório)
 

--- a/gpt/prompts.json
+++ b/gpt/prompts.json
@@ -1,0 +1,18 @@
+{
+  "criarConteudoNotion": {
+    "example": {
+      "notion_token": "seu_token",
+      "nome_database": "Me Passa A Cola (GPT)",
+      "tema": "Matemática",
+      "type": "resumo",
+      "resumo": "Conteúdo gerado"
+    }
+  },
+  "listarIssues": {
+    "example": {
+      "token": "ghp_xxx",
+      "owner": "usuario",
+      "repo": "repositorio"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "node tests/run.js",
-    "doca": "node src/doca.js"
+    "doca": "node src/doca.js",
+    "docs": "node scripts/generate-docs.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const actionsPath = path.join(__dirname, '..', 'gpt', 'actions.json');
+const promptsPath = path.join(__dirname, '..', 'gpt', 'prompts.json');
+
+const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+let prompts = {};
+if (fs.existsSync(promptsPath)) {
+  prompts = JSON.parse(fs.readFileSync(promptsPath, 'utf8'));
+}
+
+function mdEscape(text) {
+  return String(text).replace(/_/g, '\\_');
+}
+
+function generateSummary(paths) {
+  let md = '## Sumário\n';
+  for (const [route, methods] of Object.entries(paths)) {
+    for (const [method] of Object.entries(methods)) {
+      const anchor = `${method}-${route}`.replace(/[^a-zA-Z0-9]/g, '');
+      md += `- [${method.toUpperCase()} ${route}](#${anchor})\n`;
+    }
+  }
+  return md + '\n';
+}
+
+function sectionForMethod(route, method, info) {
+  const anchor = `${method}-${route}`.replace(/[^a-zA-Z0-9]/g, '');
+  let md = `### <a id="${anchor}"></a> ${method.toUpperCase()} ${route}\n\n`;
+  if (info.description) {
+    md += info.description + '\n\n';
+  }
+  if (info.parameters && info.parameters.length) {
+    md += 'Parâmetros:\n';
+    for (const p of info.parameters) {
+      const req = p.required ? ' (obrigatório)' : '';
+      const type = p.schema ? p.schema.type : 'string';
+      md += `- \`${p.name}\` (${p.in}, ${type})${req}`;
+      if (p.description) md += ` - ${mdEscape(p.description)}`;
+      md += '\n';
+    }
+    md += '\n';
+  }
+  if (info.requestBody) {
+    md += 'Corpo da requisição:\n';
+    const schema = info.requestBody.content?.['application/json']?.schema;
+    if (schema && schema['$ref']) {
+      const ref = schema['$ref'].split('/').pop();
+      const def = actions.components?.schemas?.[ref];
+      if (def && def.properties) {
+        for (const [prop, val] of Object.entries(def.properties)) {
+          const req = def.required && def.required.includes(prop) ? ' (obrigatório)' : '';
+          md += `- \`${prop}\` (${val.type})${req}\n`;
+        }
+      }
+    }
+    md += '\n';
+  }
+  const opId = info.operationId;
+  const example = prompts[opId]?.example;
+  if (example) {
+    md += 'Exemplo:\n';
+    md += '```json\n';
+    md += JSON.stringify(example, null, 2) + '\n';
+    md += '```\n\n';
+  }
+  return md;
+}
+
+function generateDocs() {
+  let md = '# API\n\n';
+  md += generateSummary(actions.paths);
+  for (const [route, methods] of Object.entries(actions.paths)) {
+    for (const [method, info] of Object.entries(methods)) {
+      md += sectionForMethod(route, method, info);
+    }
+  }
+  return md;
+}
+
+if (require.main === module) {
+  const outDir = path.join(__dirname, '..', 'docs');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  fs.writeFileSync(path.join(outDir, 'API.md'), generateDocs());
+}
+
+module.exports = generateDocs;


### PR DESCRIPTION
## Descrição
Adiciona script para gerar `docs/API.md` a partir de `gpt/actions.json` e `gpt/prompts.json`. Inclui workflow opcional para rodar a geração no GitHub Actions e atualiza o README com instruções.

## Tipo de mudança
- [x] Nova funcionalidade
- [x] Melhoria de documentação

## Checklist
- [x] Meu código segue as diretrizes do projeto
- [x] Realizei testes locais
- [x] Atualizei a documentação quando necessário

------
https://chatgpt.com/codex/tasks/task_e_6882537d36d4832cb74ea520a0356712